### PR TITLE
Add log4rs.yaml to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.26
 
 WORKDIR /usr/src/bn-api
-ADD Cargo.toml Cargo.lock ./
+ADD Cargo.toml Cargo.lock log4rs.yaml ./
 ADD tests tests/
 ADD src src/
 


### PR DESCRIPTION
The log config file is missing, causing the docker image to break