### PR TITLE
Changed the spotify results to mimic artists

### DIFF
--- a/api/src/models/artist_spotify_or_local.rs
+++ b/api/src/models/artist_spotify_or_local.rs
@@ -1,0 +1,69 @@
+use bigneon_db::models::{Artist, NewArtist};
+use chrono::NaiveDateTime;
+use uuid::Uuid;
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone, Default)]
+pub struct CreateArtist {
+    pub id: Option<Uuid>,
+    pub organization_id: Option<Uuid>,
+    pub is_private: Option<bool>,
+    pub name: Option<String>,
+    pub bio: Option<String>,
+    pub image_url: Option<String>,
+    pub thumb_image_url: Option<String>,
+    pub website_url: Option<String>,
+    pub youtube_video_urls: Option<Vec<String>>,
+    pub facebook_username: Option<String>,
+    pub instagram_username: Option<String>,
+    pub snapchat_username: Option<String>,
+    pub soundcloud_username: Option<String>,
+    pub bandcamp_username: Option<String>,
+    pub spotify_id: Option<String>,
+    pub created_at: Option<NaiveDateTime>,
+    pub updated_at: Option<NaiveDateTime>,
+}
+
+impl Into<NewArtist> for CreateArtist {
+    fn into(self) -> NewArtist {
+        let create_artist = self.clone();
+        NewArtist {
+            organization_id: create_artist.organization_id,
+            name: create_artist.name.unwrap_or("".to_string()),
+            bio: create_artist.bio.unwrap_or("".to_string()),
+            image_url: create_artist.image_url,
+            thumb_image_url: create_artist.thumb_image_url,
+            website_url: create_artist.website_url,
+            youtube_video_urls: create_artist.youtube_video_urls,
+            facebook_username: create_artist.facebook_username,
+            instagram_username: create_artist.instagram_username,
+            snapchat_username: create_artist.snapchat_username,
+            soundcloud_username: create_artist.soundcloud_username,
+            bandcamp_username: create_artist.bandcamp_username,
+            spotify_id: create_artist.spotify_id,
+        }
+    }
+}
+
+impl From<Artist> for CreateArtist {
+    fn from(artist: Artist) -> Self {
+        CreateArtist {
+            id: Some(artist.id),
+            organization_id: artist.organization_id,
+            is_private: Some(artist.is_private),
+            name: Some(artist.name),
+            bio: Some(artist.bio),
+            image_url: artist.image_url,
+            thumb_image_url: artist.thumb_image_url,
+            website_url: artist.website_url,
+            youtube_video_urls: Some(artist.youtube_video_urls),
+            facebook_username: artist.facebook_username,
+            instagram_username: artist.instagram_username,
+            snapchat_username: artist.snapchat_username,
+            soundcloud_username: artist.soundcloud_username,
+            bandcamp_username: artist.bandcamp_username,
+            spotify_id: artist.spotify_id,
+            created_at: Some(artist.created_at),
+            updated_at: Some(artist.updated_at),
+        }
+    }
+}

--- a/api/src/models/create_artist_request.rs
+++ b/api/src/models/create_artist_request.rs
@@ -3,7 +3,7 @@ use chrono::NaiveDateTime;
 use uuid::Uuid;
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone, Default)]
-pub struct CreateArtist {
+pub struct CreateArtistRequest {
     pub id: Option<Uuid>,
     pub organization_id: Option<Uuid>,
     pub is_private: Option<bool>,
@@ -23,7 +23,7 @@ pub struct CreateArtist {
     pub updated_at: Option<NaiveDateTime>,
 }
 
-impl Into<NewArtist> for CreateArtist {
+impl Into<NewArtist> for CreateArtistRequest {
     fn into(self) -> NewArtist {
         let create_artist = self.clone();
         NewArtist {
@@ -44,9 +44,9 @@ impl Into<NewArtist> for CreateArtist {
     }
 }
 
-impl From<Artist> for CreateArtist {
+impl From<Artist> for CreateArtistRequest {
     fn from(artist: Artist) -> Self {
-        CreateArtist {
+        CreateArtistRequest {
             id: Some(artist.id),
             organization_id: artist.organization_id,
             is_private: Some(artist.is_private),

--- a/api/src/models/mod.rs
+++ b/api/src/models/mod.rs
@@ -1,6 +1,6 @@
 pub use self::add_venue_to_organization_request::*;
 pub use self::admin_display_ticket_type::*;
-pub use self::artist_spotify_or_local::*;
+pub use self::create_artist_request::*;
 pub use self::display_ticket_pricing::*;
 pub use self::facebook_web_login_token::*;
 pub use self::path_parameters::*;
@@ -11,7 +11,7 @@ pub use self::user_profile_attributes::*;
 
 mod add_venue_to_organization_request;
 mod admin_display_ticket_type;
-mod artist_spotify_or_local;
+mod create_artist_request;
 mod display_ticket_pricing;
 mod facebook_web_login_token;
 mod path_parameters;

--- a/api/src/models/mod.rs
+++ b/api/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub use self::add_venue_to_organization_request::*;
 pub use self::admin_display_ticket_type::*;
+pub use self::artist_spotify_or_local::*;
 pub use self::display_ticket_pricing::*;
 pub use self::facebook_web_login_token::*;
 pub use self::path_parameters::*;
@@ -10,6 +11,7 @@ pub use self::user_profile_attributes::*;
 
 mod add_venue_to_organization_request;
 mod admin_display_ticket_type;
+mod artist_spotify_or_local;
 mod display_ticket_pricing;
 mod facebook_web_login_token;
 mod path_parameters;

--- a/api/src/routing.rs
+++ b/api/src/routing.rs
@@ -123,8 +123,6 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
     }).resource("/regions", |r| {
         r.method(Method::GET).with(regions::index);
         r.method(Method::POST).with(regions::create)
-    }).resource("/spotify/{id}", |r| {
-        r.method(Method::POST).with(artists::create_from_spotify);
     }).resource("/status", |r| {
         r.method(Method::GET).f(|_| HttpResponse::Ok())
     }).resource("/tickets/transfer", |r| {

--- a/api/src/utils/spotify.rs
+++ b/api/src/utils/spotify.rs
@@ -1,5 +1,5 @@
 use errors::{ApplicationError, BigNeonError};
-use models::CreateArtist;
+use models::CreateArtistRequest;
 use reqwest::Client;
 use serde_json;
 use serde_json::Value;
@@ -63,7 +63,7 @@ impl Spotify {
         }
     }
 
-    pub fn search(&self, q: String) -> Result<Vec<CreateArtist>, BigNeonError> {
+    pub fn search(&self, q: String) -> Result<Vec<CreateArtistRequest>, BigNeonError> {
         match &self.auth_token {
             Some(_auth_token) => {
                 let reqwest_client = Client::new();
@@ -88,7 +88,7 @@ impl Spotify {
                     .into_iter()
                     .map(|item| {
                         let artist = item;
-                        CreateArtist {
+                        CreateArtistRequest {
                             name: artist["name"].as_str().map(|s| s.to_string()),
                             bio: Some("".to_string()),
                             spotify_id: artist["id"].as_str().map(|s| s.to_string()),
@@ -101,7 +101,10 @@ impl Spotify {
         }
     }
 
-    pub fn read_artist(&self, artist_id: &str) -> Result<Option<CreateArtist>, BigNeonError> {
+    pub fn read_artist(
+        &self,
+        artist_id: &str,
+    ) -> Result<Option<CreateArtistRequest>, BigNeonError> {
         match &self.auth_token {
             Some(_auth_token) => {
                 let reqwest_client = Client::new();
@@ -124,7 +127,7 @@ impl Spotify {
                             .to_string(),
                     ).into());
                 } else {
-                    let create_artist = CreateArtist {
+                    let create_artist = CreateArtistRequest {
                         name: artist["name"].as_str().map(|s| s.to_string()),
                         bio: Some("".to_string()),
                         spotify_id: artist["id"].as_str().map(|s| s.to_string()),

--- a/api/tests/functional/artists.rs
+++ b/api/tests/functional/artists.rs
@@ -1,6 +1,5 @@
 use actix_web::{http::StatusCode, FromRequest, HttpResponse, Path, Query};
 use bigneon_api::controllers::artists;
-use bigneon_api::controllers::artists::ArtistOrSpotify;
 use bigneon_api::models::PathParameters;
 use bigneon_db::prelude::*;
 use functional::base;
@@ -182,10 +181,8 @@ pub fn search_no_spotify() {
         .payload()
         .data
         .iter()
-        .map(|i| match i {
-            ArtistOrSpotify::Artist(artist) => artist.id,
-            _ => Uuid::new_v4(),
-        }).collect::<Vec<Uuid>>();
+        .map(|i| i.id.unwrap_or(Uuid::new_v4()))
+        .collect::<Vec<Uuid>>();
 
     assert_eq!(expected_artists, collected_ids);
 }
@@ -214,10 +211,8 @@ pub fn search_with_spotify() {
         .payload()
         .data
         .iter()
-        .filter(|i| match i {
-            ArtistOrSpotify::Artist(_artist) => false,
-            ArtistOrSpotify::Spotify(_spotify) => true,
-        }).count();
+        .filter(|i| i.spotify_id.is_some())
+        .count();
     if test_request
         .extract_state()
         .config

--- a/api/tests/functional/base/artists.rs
+++ b/api/tests/functional/base/artists.rs
@@ -1,6 +1,6 @@
 use actix_web::{http::StatusCode, FromRequest, HttpResponse, Json, Path};
 use bigneon_api::controllers::artists;
-use bigneon_api::models::{CreateArtist, PathParameters};
+use bigneon_api::models::{CreateArtistRequest, PathParameters};
 use bigneon_db::models::*;
 use serde_json;
 use support;
@@ -16,7 +16,7 @@ pub fn create(role: Roles, should_test_succeed: bool) {
     let bio = "Bio";
     let website_url = "http://www.example.com";
 
-    let json = Json(CreateArtist {
+    let json = Json(CreateArtistRequest {
         organization_id: None,
         name: Some(name.to_string()),
         bio: Some(bio.to_string()),
@@ -54,7 +54,7 @@ pub fn create_with_organization(role: Roles, should_test_succeed: bool) {
     let bio = "Bio";
     let website_url = "http://www.example.com";
 
-    let json = Json(CreateArtist {
+    let json = Json(CreateArtistRequest {
         organization_id: Some(organization.id),
         name: Some(name.to_string()),
         bio: Some(bio.to_string()),
@@ -87,7 +87,7 @@ pub fn create_with_validation_errors(role: Roles, should_test_succeed: bool) {
     let name = "Artist Example";
     let bio = "Bio";
     let website_url = "invalid-format.com";
-    let json = Json(CreateArtist {
+    let json = Json(CreateArtistRequest {
         name: Some(name.to_string()),
         bio: Some(bio.to_string()),
         website_url: Some(website_url.to_string()),

--- a/api/tests/functional/base/artists.rs
+++ b/api/tests/functional/base/artists.rs
@@ -1,6 +1,6 @@
 use actix_web::{http::StatusCode, FromRequest, HttpResponse, Json, Path};
 use bigneon_api::controllers::artists;
-use bigneon_api::models::PathParameters;
+use bigneon_api::models::{CreateArtist, PathParameters};
 use bigneon_db::models::*;
 use serde_json;
 use support;
@@ -16,16 +16,21 @@ pub fn create(role: Roles, should_test_succeed: bool) {
     let bio = "Bio";
     let website_url = "http://www.example.com";
 
-    let json = Json(NewArtist {
+    let json = Json(CreateArtist {
         organization_id: None,
-        name: name.to_string(),
-        bio: bio.to_string(),
+        name: Some(name.to_string()),
+        bio: Some(bio.to_string()),
         website_url: Some(website_url.to_string()),
         ..Default::default()
     });
 
-    let response: HttpResponse =
-        artists::create((database.connection.into(), json, auth_user)).into();
+    let test_request = TestRequest::create();
+    let response: HttpResponse = artists::create((
+        test_request.extract_state(),
+        database.connection.into(),
+        json,
+        auth_user,
+    )).into();
 
     if should_test_succeed {
         let body = support::unwrap_body_to_string(&response).unwrap();
@@ -49,16 +54,21 @@ pub fn create_with_organization(role: Roles, should_test_succeed: bool) {
     let bio = "Bio";
     let website_url = "http://www.example.com";
 
-    let json = Json(NewArtist {
+    let json = Json(CreateArtist {
         organization_id: Some(organization.id),
-        name: name.to_string(),
-        bio: bio.to_string(),
+        name: Some(name.to_string()),
+        bio: Some(bio.to_string()),
         website_url: Some(website_url.to_string()),
         ..Default::default()
     });
 
-    let response: HttpResponse =
-        artists::create((database.connection.into(), json, auth_user.clone())).into();
+    let test_request = TestRequest::create();
+    let response: HttpResponse = artists::create((
+        test_request.extract_state(),
+        database.connection.into(),
+        json,
+        auth_user.clone(),
+    )).into();
 
     if should_test_succeed {
         let body = support::unwrap_body_to_string(&response).unwrap();
@@ -77,16 +87,21 @@ pub fn create_with_validation_errors(role: Roles, should_test_succeed: bool) {
     let name = "Artist Example";
     let bio = "Bio";
     let website_url = "invalid-format.com";
-    let json = Json(NewArtist {
-        name: name.to_string(),
-        bio: bio.to_string(),
+    let json = Json(CreateArtist {
+        name: Some(name.to_string()),
+        bio: Some(bio.to_string()),
         website_url: Some(website_url.to_string()),
         youtube_video_urls: Some(vec!["invalid".to_string()]),
         ..Default::default()
     });
-
+    let test_request = TestRequest::create();
     let user = support::create_auth_user(role, None, &database);
-    let response: HttpResponse = artists::create((database.connection.into(), json, user)).into();
+    let response: HttpResponse = artists::create((
+        test_request.extract_state(),
+        database.connection.into(),
+        json,
+        user,
+    )).into();
 
     if should_test_succeed {
         assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);

--- a/db/migrations/00000000000007_artists/up.sql
+++ b/db/migrations/00000000000007_artists/up.sql
@@ -14,6 +14,7 @@ CREATE TABLE artists (
   snapchat_username TEXT,
   soundcloud_username TEXT,
   bandcamp_username TEXT,
+  spotify_id TEXT,
   created_at TIMESTAMP DEFAULT now() NOT NULL,
   updated_at TIMESTAMP DEFAULT now() NOT NULL
 );

--- a/db/src/models/artists.rs
+++ b/db/src/models/artists.rs
@@ -27,6 +27,7 @@ pub struct Artist {
     pub snapchat_username: Option<String>,
     pub soundcloud_username: Option<String>,
     pub bandcamp_username: Option<String>,
+    pub spotify_id: Option<String>,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
 }
@@ -58,6 +59,8 @@ pub struct NewArtist {
     pub soundcloud_username: Option<String>,
     #[serde(default, deserialize_with = "deserialize_unless_blank")]
     pub bandcamp_username: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_unless_blank")]
+    pub spotify_id: Option<String>,
 }
 
 impl NewArtist {

--- a/db/src/schema.rs
+++ b/db/src/schema.rs
@@ -14,6 +14,7 @@ table! {
         snapchat_username -> Nullable<Text>,
         soundcloud_username -> Nullable<Text>,
         bandcamp_username -> Nullable<Text>,
+        spotify_id -> Nullable<Text>,
         created_at -> Timestamp,
         updated_at -> Timestamp,
     }

--- a/integration-tests/bigneon-tests.postman_collection.json
+++ b/integration-tests/bigneon-tests.postman_collection.json
@@ -1,8 +1,6 @@
 {
 	"info": {
-
-		"_postman_id": "37b0cace-932a-4a02-83ec-19aaf0ff0408",
-
+		"_postman_id": "691f386e-8a30-4636-bb38-207f59e11beb",
 		"name": "bigneon-tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -535,7 +533,7 @@
 									"})",
 									"",
 									"pm.test(\"Artist result should match\",function() {",
-									"    pm.expect(JSON.parse(responseBody).data[0].Artist.id).to.eq(pm.environment.get(\"last_artist_id\"));",
+									"    pm.expect(JSON.parse(responseBody).data[0].id).to.eq(pm.environment.get(\"last_artist_id\"));",
 									"});"
 								],
 								"type": "text/javascript"
@@ -562,7 +560,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"name\":\"Artist {{$timestamp}}\",\n\t\"bio\": \"Artist bio\"\n}"
+							"raw": ""
 						},
 						"url": {
 							"raw": "http://{{server}}/artists/search?q=Artist&spotify=1",
@@ -600,18 +598,12 @@
 									"    pm.response.to.have.status(200);",
 									"})",
 									"",
-									"pm.test(\"Spotify result should match\",function() {",
+									"pm.test(\"Spotify result should contain spotify_id\",function() {",
 									"    pm.environment.set(\"last_spotify_artist_id\", \"\");",
 									"    JSON.parse(responseBody).data.forEach(item => {",
-									"        if (item.Artist) {",
-									"            throw new Error(\"There should be no Artist entries\");",
-									"        }",
-									"        if (item.Spotify && item.Spotify.spotify_id === \"5HFkc3t0HYETL4JeEbDB1v\") {",
-									"            pm.expect(item.Spotify.spotify_id).to.eq(\"5HFkc3t0HYETL4JeEbDB1v\");",
-									"            pm.environment.set(\"last_spotify_artist_id\", \"5HFkc3t0HYETL4JeEbDB1v\");",
-									"        }",
+									"        pm.expect(item.spotify_id).to.not.be.a(\"null\");",
+									"        pm.environment.set(\"last_spotify_artist_id\", \"5HFkc3t0HYETL4JeEbDB1v\");",
 									"    })",
-									"    // pm.expect(JSON.parse(responseBody).data[0].Artist.id).to.eq(pm.environment.get(\"last_artist_id\"));",
 									"});"
 								],
 								"type": "text/javascript"
@@ -638,7 +630,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"name\":\"Artist {{$timestamp}}\",\n\t\"bio\": \"Artist bio\"\n}"
+							"raw": ""
 						},
 						"url": {
 							"raw": "http://{{server}}/artists/search?q=Powerwolf&spotify=1",
@@ -712,17 +704,16 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"name\":\"Artist {{$timestamp}}\",\n\t\"bio\": \"Artist bio\"\n}"
+							"raw": "{\n\t\"spotify_id\": \"{{last_spotify_artist_id}}\"\n}"
 						},
 						"url": {
-							"raw": "http://{{server}}/spotify/{{last_spotify_artist_id}}",
+							"raw": "http://{{server}}/artists",
 							"protocol": "http",
 							"host": [
 								"{{server}}"
 							],
 							"path": [
-								"spotify",
-								"{{last_spotify_artist_id}}"
+								"artists"
 							]
 						}
 					},


### PR DESCRIPTION
Closes #540 

Removed the Enum that differentiated between an artist and a spotify result. Instead a `spotify_id` field has been added to the artists table.

Search results return a `CreateArtist` struct, if it is from spotify the `spotify_id` will be populated if it is a local result then the `id` field will be populated.

The `/spotify/{id}` endpoint has been removed instead, passing a `CreateArtist` to `POST /artists/create` if the `spotify_id` field is set then it will attempt to fetch the artist details from spotify.