### PR TITLE
Merge spotify result and client data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,11 +254,11 @@ dependencies = [
 
 [[package]]
 name = "bigneon_api"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "actix 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "bigneon_db 0.1.15",
+ "bigneon_db 0.1.16",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "bigneon_db"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/api/src/controllers/artists.rs
+++ b/api/src/controllers/artists.rs
@@ -80,11 +80,12 @@ pub fn create(
         Some(spotify_id) => {
             let auth_token = state.config.spotify_auth_token.clone();
             let spotify_client = Spotify::connect(auth_token)?;
-            println!("Spotify ID {}", spotify_id);
             let spotify_artist_result = spotify_client.read_artist(&spotify_id)?;
             match spotify_artist_result {
                 Some(artist) => {
-                    let new_artist: NewArtist = artist.into();
+                    let mut new_artist: NewArtist = artist.into();
+                    let client_data: NewArtist = create_artist.clone().into();
+                    new_artist.merge(client_data);
                     new_artist.commit(connection)?
                 }
                 None => return application::not_found(),

--- a/api/src/utils/spotify.rs
+++ b/api/src/utils/spotify.rs
@@ -133,12 +133,14 @@ impl Spotify {
                     .into());
                 } else {
                     let image_url = Spotify::get_image_from_artist(&artist["images"], Some(0));
+                    let thumb_image_url = Spotify::get_image_from_artist(&artist["images"], None);
 
                     let create_artist = CreateArtistRequest {
                         name: artist["name"].as_str().map(|s| s.to_string()),
                         bio: Some("".to_string()),
                         spotify_id: artist["id"].as_str().map(|s| s.to_string()),
                         image_url,
+                        thumb_image_url,
                         ..Default::default()
                     };
                     Ok(Some(create_artist))

--- a/db/src/models/artists.rs
+++ b/db/src/models/artists.rs
@@ -74,6 +74,42 @@ impl NewArtist {
                 .get_result(conn),
         )
     }
+
+    pub fn merge(&mut self, new_artist: NewArtist) {
+        if self.bio == "" {
+            self.bio = new_artist.bio;
+        }
+        if let None = self.image_url {
+            self.image_url = new_artist.image_url;
+        }
+        if let None = self.thumb_image_url {
+            self.thumb_image_url = new_artist.thumb_image_url;
+        }
+        if let None = self.website_url {
+            self.website_url = new_artist.website_url;
+        }
+        if let None = self.youtube_video_urls {
+            self.youtube_video_urls = new_artist.youtube_video_urls;
+        }
+        if let None = self.facebook_username {
+            self.facebook_username = new_artist.facebook_username;
+        }
+        if let None = self.instagram_username {
+            self.instagram_username = new_artist.instagram_username;
+        }
+        if let None = self.snapchat_username {
+            self.snapchat_username = new_artist.snapchat_username;
+        }
+        if let None = self.soundcloud_username {
+            self.soundcloud_username = new_artist.soundcloud_username;
+        }
+        if let None = self.bandcamp_username {
+            self.bandcamp_username = new_artist.bandcamp_username;
+        }
+        if let None = self.spotify_id {
+            self.spotify_id = new_artist.spotify_id;
+        }
+    }
 }
 
 impl Artist {


### PR DESCRIPTION
When creating an artist from spotify, merge in any other data that was sent along with it such as bio's and 3rd party urls