### PR TITLE
Provide remaining # of tickets for limited tickets in cart on PUT, POST and GET /cart

### DIFF
--- a/api/src/controllers/events.rs
+++ b/api/src/controllers/events.rs
@@ -299,7 +299,7 @@ pub fn show(
             }
         }
     }
-    
+
     #[derive(Serialize)]
     struct R {
         id: Uuid,

--- a/api/src/controllers/events.rs
+++ b/api/src/controllers/events.rs
@@ -243,7 +243,7 @@ pub fn show(
     let box_office_pricing = query.box_office_pricing.unwrap_or(false);
     if box_office_pricing {
         match user {
-            Some(user) => user.requires_scope_for_organization(
+            Some(ref user) => user.requires_scope_for_organization(
                 Scopes::BoxOfficeTicketRead,
                 &organization,
                 connection,
@@ -280,6 +280,27 @@ pub fn show(
     }
 
     #[derive(Serialize)]
+    pub struct TicketsRemaining {
+        pub ticket_type_id: Uuid,
+        pub tickets_remaining: i32,
+    }
+
+    let mut limited_tickets_remaining: Vec<TicketsRemaining> = Vec::new();
+
+    if let Some(u) = user {
+        let tickets_bought = Order::quantity_for_user_for_event(&u.id(), &event.id, connection)?;
+        for (tt_id, num) in tickets_bought {
+            let limit = TicketType::find(tt_id, connection)?.limit_per_person;
+            if limit > 0 {
+                limited_tickets_remaining.push(TicketsRemaining {
+                    ticket_type_id: tt_id,
+                    tickets_remaining: limit - num,
+                });
+            }
+        }
+    }
+    
+    #[derive(Serialize)]
     struct R {
         id: Uuid,
         name: String,
@@ -307,6 +328,7 @@ pub fn show(
         is_external: bool,
         external_url: Option<String>,
         override_status: Option<EventOverrideStatus>,
+        limited_tickets_remaining: Vec<TicketsRemaining>,
     }
 
     Ok(HttpResponse::Ok().json(&R {
@@ -339,6 +361,7 @@ pub fn show(
         is_external: event.is_external,
         external_url: event.external_url,
         override_status: event.override_status,
+        limited_tickets_remaining,
     }))
 }
 

--- a/api/tests/functional/base/events.rs
+++ b/api/tests/functional/base/events.rs
@@ -671,6 +671,15 @@ pub fn expected_show_json(
         id: Uuid,
         name: String,
     }
+
+    #[derive(Serialize)]
+    pub struct TicketsRemaining {
+        pub ticket_type_id: Uuid,
+        pub tickets_remaining: i32,
+    }
+
+    let no_tickets_remaining: Vec<TicketsRemaining> = Vec::new();
+
     #[derive(Serialize)]
     struct R {
         id: Uuid,
@@ -699,6 +708,7 @@ pub fn expected_show_json(
         is_external: bool,
         external_url: Option<String>,
         override_status: Option<EventOverrideStatus>,
+        limited_tickets_remaining: Vec<TicketsRemaining>,
     }
 
     let fee_schedule = FeeSchedule::find(organization.fee_schedule_id, connection).unwrap();
@@ -749,6 +759,7 @@ pub fn expected_show_json(
         is_external: event.is_external,
         external_url: event.external_url,
         override_status: event.override_status,
+        limited_tickets_remaining: no_tickets_remaining,
     })
     .unwrap()
 }

--- a/integration-tests/bigneon-tests.postman_collection.json
+++ b/integration-tests/bigneon-tests.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b9cecddd-dac4-4990-bb86-2c7e104c35a2",
+		"_postman_id": "8b249643-ca19-4f12-a805-d06875366c88",
 		"name": "bigneon-tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -6616,7 +6616,16 @@
 									"",
 									"pm.test(\"total should be correct\", function() {",
 									"    pm.expect(json.total_in_cents).to.equal(27190);",
-									"})",
+									"});",
+									"",
+									"pm.test(\"should be only 1 ticket_type with a limit\", function() {",
+									"   pm.expect(json.limited_tickets_remaining.length).to.equal(1); ",
+									"});",
+									"",
+									"pm.test(\"should report 48 remaining tickets available\", function() {",
+									"    pm.expect(json.limited_tickets_remaining[0].tickets_remaining).to.equal(48);",
+									"});",
+									"",
 									""
 								],
 								"type": "text/javascript"
@@ -6906,6 +6915,10 @@
 									"pm.test(\"total should be correct\", function() {",
 									"    pm.expect(json.total_in_cents).to.equal(60300);",
 									"})",
+									"",
+									"pm.test(\"should report 30 remaining tickets available\", function() {",
+									"    pm.expect(json.limited_tickets_remaining[0].tickets_remaining).to.equal(30);",
+									"});",
 									""
 								],
 								"type": "text/javascript"
@@ -7242,6 +7255,10 @@
 									"pm.test(\"total should be correct\", function() {",
 									"    pm.expect(json.total_in_cents).to.equal(12140);",
 									"})",
+									"",
+									"pm.test(\"should report 46 remaining tickets available\", function() {",
+									"    pm.expect(json.limited_tickets_remaining[0].tickets_remaining).to.equal(46);",
+									"});",
 									""
 								],
 								"type": "text/javascript"
@@ -7952,6 +7969,10 @@
 									"pm.test(\"total should be correct\", function() {",
 									"    pm.expect(json.total_in_cents).to.equal(6120);",
 									"})",
+									"",
+									"pm.test(\"should report 47 remaining tickets available\", function() {",
+									"    pm.expect(json.limited_tickets_remaining[0].tickets_remaining).to.equal(47);",
+									"});",
 									""
 								],
 								"type": "text/javascript"


### PR DESCRIPTION
Closes https://github.com/big-neon/bn-api/issues/800

Added an extra field to the DisplayOrder structure returned by order.for_display(...) which checks all the order_items in the order and if any of those are for tickets with a limit_per_user will add them to the array in the `limited_tickets_remaining` field as a (ticket_type_id, tickets_remaining) pair.

To test this I updated the postman tests to test the functionality on a PUT, POST and GET /cart calls i a few places in the postman tests. I also confirmed that tickets without a limit are NOT included in this array.