### PR TITLE
unpublish event

### DIFF
--- a/api/src/controllers/events.rs
+++ b/api/src/controllers/events.rs
@@ -375,6 +375,16 @@ pub fn publish(
     Ok(HttpResponse::Ok().finish())
 }
 
+pub fn unpublish(
+    (connection, path, user): (Connection, Path<PathParameters>, User),
+) -> Result<HttpResponse, BigNeonError> {
+    let conn = connection.get();
+    let event = Event::find(path.id, conn)?;
+    user.requires_scope_for_organization(Scopes::EventWrite, &event.organization(conn)?, conn)?;
+    event.unpublish(conn)?;
+    Ok(HttpResponse::Ok().finish())
+}
+
 #[derive(Deserialize, Serialize, Debug)]
 pub struct TicketRedeemRequest {
     pub redeem_key: String,

--- a/api/src/routing.rs
+++ b/api/src/routing.rs
@@ -8,269 +8,269 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
     app.resource("/artists/search", |r| {
         r.method(Method::GET).with(artists::search);
     })
-        .resource("/artists/{id}/toggle_privacy", |r| {
-            r.method(Method::PUT).with(artists::toggle_privacy);
-        })
-        .resource("/artists/{id}", |r| {
-            r.method(Method::GET).with(artists::show);
-            r.method(Method::PUT).with(artists::update);
-        })
-        .resource("/artists", |r| {
-            r.method(Method::GET).with(artists::index);
-            r.method(Method::POST).with(artists::create);
-        })
-        .resource("/auth/token", |r| r.method(Method::POST).with(auth::token))
-        .resource("/auth/token/refresh", |r| {
-            r.method(Method::POST).with(auth::token_refresh)
-        })
-        .resource("/cart", |r| {
-            r.method(Method::DELETE).with(cart::destroy);
-            r.method(Method::POST).with(cart::update_cart);
-            r.method(Method::PUT).with(cart::replace_cart);
-            r.method(Method::GET).with(cart::show);
-        })
-        .resource("/cart/checkout", |r| {
-            r.method(Method::POST).with(cart::checkout);
-        })
-        .resource("/codes/{id}", |r| {
-            r.method(Method::GET).with(codes::show);
-            r.method(Method::PUT).with(codes::update);
-            r.method(Method::DELETE).with(codes::destroy);
-        })
-        .resource("/comps/{id}", |r| {
-            r.method(Method::GET).with(comps::show);
-            r.method(Method::PATCH).with(comps::update);
-            r.method(Method::DELETE).with(comps::destroy);
-        })
-        .resource("/events", |r| {
-            r.method(Method::GET).with(events::index);
-            r.method(Method::POST).with(events::create);
-        })
-        .resource("/events/checkins", |r| {
-            r.method(Method::GET).with(events::checkins);
-        })
-        .resource("/events/{id}", |r| {
-            r.method(Method::GET).with(events::show);
-            r.method(Method::PUT).with(events::update);
-            r.method(Method::DELETE).with(events::cancel);
-        })
-        .resource("/events/{id}/artists", |r| {
-            r.method(Method::POST).with(events::add_artist);
-            r.method(Method::PUT).with(events::update_artists);
-        })
-        .resource("/events/{id}/codes", |r| {
-            r.method(Method::GET).with(events::codes);
-            r.method(Method::POST).with(codes::create);
-        })
-        .resource("/events/{id}/dashboard", |r| {
-            r.method(Method::GET).with(events::dashboard);
-        })
-        .resource("/events/{id}/guests", |r| {
-            r.method(Method::GET).with(events::guest_list);
-        })
-        .resource("/events/{id}/holds", |r| {
-            r.method(Method::POST).with(holds::create);
-            r.method(Method::GET).with(events::holds);
-        })
-        .resource("/events/{id}/interest", |r| {
-            r.method(Method::GET).with(events::list_interested_users);
-            r.method(Method::POST).with(events::add_interest);
-            r.method(Method::DELETE).with(events::remove_interest);
-        })
-        .resource("/events/{id}/publish", |r| {
-            r.method(Method::POST).with(events::publish);
-        })
-        .resource("/events/{id}/unpublish", |r| {
-            r.method(Method::POST).with(events::unpublish);
-        })
-        .resource("/events/{id}/redeem/{ticket_instance_id}", |r| {
-            r.method(Method::POST).with(events::redeem_ticket);
-        })
-        .resource("/events/{id}/tickets", |r| {
-            r.method(Method::GET).with(tickets::index);
-        })
-        .resource("/events/{id}/ticket_types", |r| {
-            r.method(Method::GET).with(ticket_types::index);
-            r.method(Method::POST).with(ticket_types::create);
-        })
-        .resource("/events/{event_id}/ticket_types/{ticket_type_id}", |r| {
-            r.method(Method::PATCH).with(ticket_types::update);
-        })
-        .resource("/external/facebook/web_login", |r| {
-            r.method(Method::POST).with(external::facebook::web_login)
-        })
-        .resource("/invitations/{id}", |r| {
-            r.method(Method::GET).with(organization_invites::view);
-        })
-        .resource("/invitations", |r| {
-            r.method(Method::POST)
-                .with(organization_invites::accept_request);
-        })
-        .resource("/holds/{id}/comps", |r| {
-            r.method(Method::GET).with(comps::index);
-            r.method(Method::POST).with(comps::create);
-        })
-        .resource("/holds/{id}/split", |r| {
-            r.method(Method::POST).with(holds::split);
-        })
-        .resource("/holds/{id}", |r| {
-            r.method(Method::PATCH).with(holds::update);
-            r.method(Method::GET).with(holds::show);
-            r.method(Method::DELETE).with(holds::destroy);
-        })
-        .resource("/orders", |r| {
-            r.method(Method::GET).with(orders::index);
-        })
-        .resource("/orders/{id}/tickets", |r| {
-            r.method(Method::GET).with(orders::tickets);
-        })
-        .resource("/orders/{id}", |r| {
-            r.method(Method::GET).with(orders::show);
-            r.method(Method::PATCH).with(orders::update);
-        })
-        .resource("/organizations/{id}/artists", |r| {
-            r.method(Method::GET).with(artists::show_from_organizations);
-            r.method(Method::POST).with(organizations::add_artist);
-        })
-        .resource("/organizations/{id}/events", |r| {
-            r.method(Method::GET).with(events::show_from_organizations);
-        })
-        .resource("/organizations/{id}/fans/{user_id}/history", |r| {
-            r.method(Method::GET).with(users::history);
-        })
-        .resource("/organizations/{id}/fans/{user_id}", |r| {
-            r.method(Method::GET).with(users::profile);
-        })
-        .resource("/organizations/{id}/fee_schedule", |r| {
-            r.method(Method::GET).with(organizations::show_fee_schedule);
-            r.method(Method::POST).with(organizations::add_fee_schedule);
-        })
-        .resource("/organizations/{id}/fans", |r| {
-            r.method(Method::GET).with(organizations::search_fans);
-        })
-        .resource("/organizations/{id}/invites/{invite_id}", |r| {
-            r.method(Method::DELETE).with(organization_invites::destroy);
-        })
-        .resource("/organizations/{id}/invites", |r| {
-            r.method(Method::GET).with(organization_invites::index);
-            r.method(Method::POST).with(organization_invites::create);
-        })
-        .resource("/organizations/{id}/users", |r| {
-            r.method(Method::POST)
-                .with(organizations::add_or_replace_user);
-            r.method(Method::PUT)
-                .with(organizations::add_or_replace_user);
-            r.method(Method::GET)
-                .with(organizations::list_organization_members);
-        })
-        .resource("/organizations/{id}/users/{user_id}", |r| {
-            r.method(Method::DELETE).with(organizations::remove_user);
-        })
-        .resource("/organizations/{id}/venues", |r| {
-            r.method(Method::GET).with(venues::show_from_organizations);
-            r.method(Method::POST).with(organizations::add_venue);
-        })
-        .resource("/organizations/{id}", |r| {
-            r.method(Method::GET).with(organizations::show);
-            r.method(Method::PATCH).with(organizations::update);
-        })
-        .resource("/organizations", |r| {
-            r.method(Method::GET).with(organizations::index);
-            r.method(Method::POST).with(organizations::create);
-        })
-        .resource("/password_reset", |r| {
-            r.method(Method::POST).with(password_resets::create);
-            r.method(Method::PUT).with(password_resets::update);
-        })
-        .resource("/payment_methods", |r| {
-            r.method(Method::GET).with(payment_methods::index);
-        })
-        .resource("/regions/{id}", |r| {
-            r.method(Method::GET).with(regions::show);
-            r.method(Method::PUT).with(regions::update);
-        })
-        .resource("/regions", |r| {
-            r.method(Method::GET).with(regions::index);
-            r.method(Method::POST).with(regions::create)
-        })
-        .resource("/reports/{id}", |r| {
-            r.method(Method::GET).with(reports::get_report);
-        })
-        .resource("/status", |r| {
-            r.method(Method::GET).f(|_| HttpResponse::Ok())
-        })
-        .resource("/tickets/transfer", |r| {
-            r.method(Method::POST).with(tickets::transfer_authorization);
-        })
-        .resource("/tickets/receive", |r| {
-            r.method(Method::POST).with(tickets::receive_transfer);
-        })
-        .resource("/tickets/send", |r| {
-            r.method(Method::POST)
-                .with(tickets::send_via_email_or_phone);
-        })
-        .resource("/tickets/{id}", |r| {
-            r.method(Method::GET).with(tickets::show);
-        })
-        .resource("/tickets", |r| {
-            r.method(Method::GET).with(tickets::index);
-        })
-        .resource("/tickets/{id}/redeem", |r| {
-            r.method(Method::GET).with(tickets::show_redeemable_ticket);
-        })
-        .resource("/users/me", |r| {
-            r.method(Method::GET).with(users::current_user);
-            r.method(Method::PUT).with(users::update_current_user);
-        })
-        .resource("/users/register", |r| {
-            r.method(Method::POST).with(users::register)
-        })
-        .resource("/users/{id}/tokens", |r| {
-            r.method(Method::GET)
-                .with(users::show_push_notification_tokens_for_user_id);
-        })
-        .resource("/users/tokens", |r| {
-            r.method(Method::GET)
-                .with(users::show_push_notification_tokens);
-            r.method(Method::POST)
-                .with(users::add_push_notification_token);
-        })
-        .resource("/users/tokens/{id}", |r| {
-            r.method(Method::DELETE)
-                .with(users::remove_push_notification_token);
-        })
-        .resource("/users", |r| {
-            r.method(Method::POST).with(users::register_and_login);
-        })
-        .resource("/users/{id}", |r| {
-            r.method(Method::GET).with(users::show);
-        })
-        .resource("/user_invites", |r| {
-            r.method(Method::POST).with(user_invites::create);
-        })
-        .resource("/users/{id}/organizations", |r| {
-            r.method(Method::GET).with(users::list_organizations);
-        })
-        .resource("/venues/{id}/events", |r| {
-            r.method(Method::GET).with(events::show_from_venues);
-        })
-        .resource("/venues/{id}/organizations", |r| {
-            r.method(Method::POST).with(venues::add_to_organization);
-        })
-        .resource("/venues/{id}/toggle_privacy", |r| {
-            r.method(Method::PUT).with(venues::toggle_privacy);
-        })
-        .resource("/venues/{id}", |r| {
-            r.method(Method::GET).with(venues::show);
-            r.method(Method::PUT).with(venues::update);
-        })
-        .resource("/venues", |r| {
-            r.method(Method::GET).with(venues::index);
-            r.method(Method::POST).with(venues::create);
-        })
-        .register()
-        .default_resource(|r| {
-            r.method(Method::GET)
-                .f(|_req| HttpResponse::NotFound().json(json!({"error": "Not found"})));
-        })
+    .resource("/artists/{id}/toggle_privacy", |r| {
+        r.method(Method::PUT).with(artists::toggle_privacy);
+    })
+    .resource("/artists/{id}", |r| {
+        r.method(Method::GET).with(artists::show);
+        r.method(Method::PUT).with(artists::update);
+    })
+    .resource("/artists", |r| {
+        r.method(Method::GET).with(artists::index);
+        r.method(Method::POST).with(artists::create);
+    })
+    .resource("/auth/token", |r| r.method(Method::POST).with(auth::token))
+    .resource("/auth/token/refresh", |r| {
+        r.method(Method::POST).with(auth::token_refresh)
+    })
+    .resource("/cart", |r| {
+        r.method(Method::DELETE).with(cart::destroy);
+        r.method(Method::POST).with(cart::update_cart);
+        r.method(Method::PUT).with(cart::replace_cart);
+        r.method(Method::GET).with(cart::show);
+    })
+    .resource("/cart/checkout", |r| {
+        r.method(Method::POST).with(cart::checkout);
+    })
+    .resource("/codes/{id}", |r| {
+        r.method(Method::GET).with(codes::show);
+        r.method(Method::PUT).with(codes::update);
+        r.method(Method::DELETE).with(codes::destroy);
+    })
+    .resource("/comps/{id}", |r| {
+        r.method(Method::GET).with(comps::show);
+        r.method(Method::PATCH).with(comps::update);
+        r.method(Method::DELETE).with(comps::destroy);
+    })
+    .resource("/events", |r| {
+        r.method(Method::GET).with(events::index);
+        r.method(Method::POST).with(events::create);
+    })
+    .resource("/events/checkins", |r| {
+        r.method(Method::GET).with(events::checkins);
+    })
+    .resource("/events/{id}", |r| {
+        r.method(Method::GET).with(events::show);
+        r.method(Method::PUT).with(events::update);
+        r.method(Method::DELETE).with(events::cancel);
+    })
+    .resource("/events/{id}/artists", |r| {
+        r.method(Method::POST).with(events::add_artist);
+        r.method(Method::PUT).with(events::update_artists);
+    })
+    .resource("/events/{id}/codes", |r| {
+        r.method(Method::GET).with(events::codes);
+        r.method(Method::POST).with(codes::create);
+    })
+    .resource("/events/{id}/dashboard", |r| {
+        r.method(Method::GET).with(events::dashboard);
+    })
+    .resource("/events/{id}/guests", |r| {
+        r.method(Method::GET).with(events::guest_list);
+    })
+    .resource("/events/{id}/holds", |r| {
+        r.method(Method::POST).with(holds::create);
+        r.method(Method::GET).with(events::holds);
+    })
+    .resource("/events/{id}/interest", |r| {
+        r.method(Method::GET).with(events::list_interested_users);
+        r.method(Method::POST).with(events::add_interest);
+        r.method(Method::DELETE).with(events::remove_interest);
+    })
+    .resource("/events/{id}/publish", |r| {
+        r.method(Method::POST).with(events::publish);
+    })
+    .resource("/events/{id}/unpublish", |r| {
+        r.method(Method::POST).with(events::unpublish);
+    })
+    .resource("/events/{id}/redeem/{ticket_instance_id}", |r| {
+        r.method(Method::POST).with(events::redeem_ticket);
+    })
+    .resource("/events/{id}/tickets", |r| {
+        r.method(Method::GET).with(tickets::index);
+    })
+    .resource("/events/{id}/ticket_types", |r| {
+        r.method(Method::GET).with(ticket_types::index);
+        r.method(Method::POST).with(ticket_types::create);
+    })
+    .resource("/events/{event_id}/ticket_types/{ticket_type_id}", |r| {
+        r.method(Method::PATCH).with(ticket_types::update);
+    })
+    .resource("/external/facebook/web_login", |r| {
+        r.method(Method::POST).with(external::facebook::web_login)
+    })
+    .resource("/invitations/{id}", |r| {
+        r.method(Method::GET).with(organization_invites::view);
+    })
+    .resource("/invitations", |r| {
+        r.method(Method::POST)
+            .with(organization_invites::accept_request);
+    })
+    .resource("/holds/{id}/comps", |r| {
+        r.method(Method::GET).with(comps::index);
+        r.method(Method::POST).with(comps::create);
+    })
+    .resource("/holds/{id}/split", |r| {
+        r.method(Method::POST).with(holds::split);
+    })
+    .resource("/holds/{id}", |r| {
+        r.method(Method::PATCH).with(holds::update);
+        r.method(Method::GET).with(holds::show);
+        r.method(Method::DELETE).with(holds::destroy);
+    })
+    .resource("/orders", |r| {
+        r.method(Method::GET).with(orders::index);
+    })
+    .resource("/orders/{id}/tickets", |r| {
+        r.method(Method::GET).with(orders::tickets);
+    })
+    .resource("/orders/{id}", |r| {
+        r.method(Method::GET).with(orders::show);
+        r.method(Method::PATCH).with(orders::update);
+    })
+    .resource("/organizations/{id}/artists", |r| {
+        r.method(Method::GET).with(artists::show_from_organizations);
+        r.method(Method::POST).with(organizations::add_artist);
+    })
+    .resource("/organizations/{id}/events", |r| {
+        r.method(Method::GET).with(events::show_from_organizations);
+    })
+    .resource("/organizations/{id}/fans/{user_id}/history", |r| {
+        r.method(Method::GET).with(users::history);
+    })
+    .resource("/organizations/{id}/fans/{user_id}", |r| {
+        r.method(Method::GET).with(users::profile);
+    })
+    .resource("/organizations/{id}/fee_schedule", |r| {
+        r.method(Method::GET).with(organizations::show_fee_schedule);
+        r.method(Method::POST).with(organizations::add_fee_schedule);
+    })
+    .resource("/organizations/{id}/fans", |r| {
+        r.method(Method::GET).with(organizations::search_fans);
+    })
+    .resource("/organizations/{id}/invites/{invite_id}", |r| {
+        r.method(Method::DELETE).with(organization_invites::destroy);
+    })
+    .resource("/organizations/{id}/invites", |r| {
+        r.method(Method::GET).with(organization_invites::index);
+        r.method(Method::POST).with(organization_invites::create);
+    })
+    .resource("/organizations/{id}/users", |r| {
+        r.method(Method::POST)
+            .with(organizations::add_or_replace_user);
+        r.method(Method::PUT)
+            .with(organizations::add_or_replace_user);
+        r.method(Method::GET)
+            .with(organizations::list_organization_members);
+    })
+    .resource("/organizations/{id}/users/{user_id}", |r| {
+        r.method(Method::DELETE).with(organizations::remove_user);
+    })
+    .resource("/organizations/{id}/venues", |r| {
+        r.method(Method::GET).with(venues::show_from_organizations);
+        r.method(Method::POST).with(organizations::add_venue);
+    })
+    .resource("/organizations/{id}", |r| {
+        r.method(Method::GET).with(organizations::show);
+        r.method(Method::PATCH).with(organizations::update);
+    })
+    .resource("/organizations", |r| {
+        r.method(Method::GET).with(organizations::index);
+        r.method(Method::POST).with(organizations::create);
+    })
+    .resource("/password_reset", |r| {
+        r.method(Method::POST).with(password_resets::create);
+        r.method(Method::PUT).with(password_resets::update);
+    })
+    .resource("/payment_methods", |r| {
+        r.method(Method::GET).with(payment_methods::index);
+    })
+    .resource("/regions/{id}", |r| {
+        r.method(Method::GET).with(regions::show);
+        r.method(Method::PUT).with(regions::update);
+    })
+    .resource("/regions", |r| {
+        r.method(Method::GET).with(regions::index);
+        r.method(Method::POST).with(regions::create)
+    })
+    .resource("/reports/{id}", |r| {
+        r.method(Method::GET).with(reports::get_report);
+    })
+    .resource("/status", |r| {
+        r.method(Method::GET).f(|_| HttpResponse::Ok())
+    })
+    .resource("/tickets/transfer", |r| {
+        r.method(Method::POST).with(tickets::transfer_authorization);
+    })
+    .resource("/tickets/receive", |r| {
+        r.method(Method::POST).with(tickets::receive_transfer);
+    })
+    .resource("/tickets/send", |r| {
+        r.method(Method::POST)
+            .with(tickets::send_via_email_or_phone);
+    })
+    .resource("/tickets/{id}", |r| {
+        r.method(Method::GET).with(tickets::show);
+    })
+    .resource("/tickets", |r| {
+        r.method(Method::GET).with(tickets::index);
+    })
+    .resource("/tickets/{id}/redeem", |r| {
+        r.method(Method::GET).with(tickets::show_redeemable_ticket);
+    })
+    .resource("/users/me", |r| {
+        r.method(Method::GET).with(users::current_user);
+        r.method(Method::PUT).with(users::update_current_user);
+    })
+    .resource("/users/register", |r| {
+        r.method(Method::POST).with(users::register)
+    })
+    .resource("/users/{id}/tokens", |r| {
+        r.method(Method::GET)
+            .with(users::show_push_notification_tokens_for_user_id);
+    })
+    .resource("/users/tokens", |r| {
+        r.method(Method::GET)
+            .with(users::show_push_notification_tokens);
+        r.method(Method::POST)
+            .with(users::add_push_notification_token);
+    })
+    .resource("/users/tokens/{id}", |r| {
+        r.method(Method::DELETE)
+            .with(users::remove_push_notification_token);
+    })
+    .resource("/users", |r| {
+        r.method(Method::POST).with(users::register_and_login);
+    })
+    .resource("/users/{id}", |r| {
+        r.method(Method::GET).with(users::show);
+    })
+    .resource("/user_invites", |r| {
+        r.method(Method::POST).with(user_invites::create);
+    })
+    .resource("/users/{id}/organizations", |r| {
+        r.method(Method::GET).with(users::list_organizations);
+    })
+    .resource("/venues/{id}/events", |r| {
+        r.method(Method::GET).with(events::show_from_venues);
+    })
+    .resource("/venues/{id}/organizations", |r| {
+        r.method(Method::POST).with(venues::add_to_organization);
+    })
+    .resource("/venues/{id}/toggle_privacy", |r| {
+        r.method(Method::PUT).with(venues::toggle_privacy);
+    })
+    .resource("/venues/{id}", |r| {
+        r.method(Method::GET).with(venues::show);
+        r.method(Method::PUT).with(venues::update);
+    })
+    .resource("/venues", |r| {
+        r.method(Method::GET).with(venues::index);
+        r.method(Method::POST).with(venues::create);
+    })
+    .register()
+    .default_resource(|r| {
+        r.method(Method::GET)
+            .f(|_req| HttpResponse::NotFound().json(json!({"error": "Not found"})));
+    })
 }

--- a/api/src/routing.rs
+++ b/api/src/routing.rs
@@ -8,266 +8,269 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
     app.resource("/artists/search", |r| {
         r.method(Method::GET).with(artists::search);
     })
-    .resource("/artists/{id}/toggle_privacy", |r| {
-        r.method(Method::PUT).with(artists::toggle_privacy);
-    })
-    .resource("/artists/{id}", |r| {
-        r.method(Method::GET).with(artists::show);
-        r.method(Method::PUT).with(artists::update);
-    })
-    .resource("/artists", |r| {
-        r.method(Method::GET).with(artists::index);
-        r.method(Method::POST).with(artists::create);
-    })
-    .resource("/auth/token", |r| r.method(Method::POST).with(auth::token))
-    .resource("/auth/token/refresh", |r| {
-        r.method(Method::POST).with(auth::token_refresh)
-    })
-    .resource("/cart", |r| {
-        r.method(Method::DELETE).with(cart::destroy);
-        r.method(Method::POST).with(cart::update_cart);
-        r.method(Method::PUT).with(cart::replace_cart);
-        r.method(Method::GET).with(cart::show);
-    })
-    .resource("/cart/checkout", |r| {
-        r.method(Method::POST).with(cart::checkout);
-    })
-    .resource("/codes/{id}", |r| {
-        r.method(Method::GET).with(codes::show);
-        r.method(Method::PUT).with(codes::update);
-        r.method(Method::DELETE).with(codes::destroy);
-    })
-    .resource("/comps/{id}", |r| {
-        r.method(Method::GET).with(comps::show);
-        r.method(Method::PATCH).with(comps::update);
-        r.method(Method::DELETE).with(comps::destroy);
-    })
-    .resource("/events", |r| {
-        r.method(Method::GET).with(events::index);
-        r.method(Method::POST).with(events::create);
-    })
-    .resource("/events/checkins", |r| {
-        r.method(Method::GET).with(events::checkins);
-    })
-    .resource("/events/{id}", |r| {
-        r.method(Method::GET).with(events::show);
-        r.method(Method::PUT).with(events::update);
-        r.method(Method::DELETE).with(events::cancel);
-    })
-    .resource("/events/{id}/artists", |r| {
-        r.method(Method::POST).with(events::add_artist);
-        r.method(Method::PUT).with(events::update_artists);
-    })
-    .resource("/events/{id}/codes", |r| {
-        r.method(Method::GET).with(events::codes);
-        r.method(Method::POST).with(codes::create);
-    })
-    .resource("/events/{id}/dashboard", |r| {
-        r.method(Method::GET).with(events::dashboard);
-    })
-    .resource("/events/{id}/guests", |r| {
-        r.method(Method::GET).with(events::guest_list);
-    })
-    .resource("/events/{id}/holds", |r| {
-        r.method(Method::POST).with(holds::create);
-        r.method(Method::GET).with(events::holds);
-    })
-    .resource("/events/{id}/interest", |r| {
-        r.method(Method::GET).with(events::list_interested_users);
-        r.method(Method::POST).with(events::add_interest);
-        r.method(Method::DELETE).with(events::remove_interest);
-    })
-    .resource("/events/{id}/publish", |r| {
-        r.method(Method::POST).with(events::publish);
-    })
-    .resource("/events/{id}/redeem/{ticket_instance_id}", |r| {
-        r.method(Method::POST).with(events::redeem_ticket);
-    })
-    .resource("/events/{id}/tickets", |r| {
-        r.method(Method::GET).with(tickets::index);
-    })
-    .resource("/events/{id}/ticket_types", |r| {
-        r.method(Method::GET).with(ticket_types::index);
-        r.method(Method::POST).with(ticket_types::create);
-    })
-    .resource("/events/{event_id}/ticket_types/{ticket_type_id}", |r| {
-        r.method(Method::PATCH).with(ticket_types::update);
-    })
-    .resource("/external/facebook/web_login", |r| {
-        r.method(Method::POST).with(external::facebook::web_login)
-    })
-    .resource("/invitations/{id}", |r| {
-        r.method(Method::GET).with(organization_invites::view);
-    })
-    .resource("/invitations", |r| {
-        r.method(Method::POST)
-            .with(organization_invites::accept_request);
-    })
-    .resource("/holds/{id}/comps", |r| {
-        r.method(Method::GET).with(comps::index);
-        r.method(Method::POST).with(comps::create);
-    })
-    .resource("/holds/{id}/split", |r| {
-        r.method(Method::POST).with(holds::split);
-    })
-    .resource("/holds/{id}", |r| {
-        r.method(Method::PATCH).with(holds::update);
-        r.method(Method::GET).with(holds::show);
-        r.method(Method::DELETE).with(holds::destroy);
-    })
-    .resource("/orders", |r| {
-        r.method(Method::GET).with(orders::index);
-    })
-    .resource("/orders/{id}/tickets", |r| {
-        r.method(Method::GET).with(orders::tickets);
-    })
-    .resource("/orders/{id}", |r| {
-        r.method(Method::GET).with(orders::show);
-        r.method(Method::PATCH).with(orders::update);
-    })
-    .resource("/organizations/{id}/artists", |r| {
-        r.method(Method::GET).with(artists::show_from_organizations);
-        r.method(Method::POST).with(organizations::add_artist);
-    })
-    .resource("/organizations/{id}/events", |r| {
-        r.method(Method::GET).with(events::show_from_organizations);
-    })
-    .resource("/organizations/{id}/fans/{user_id}/history", |r| {
-        r.method(Method::GET).with(users::history);
-    })
-    .resource("/organizations/{id}/fans/{user_id}", |r| {
-        r.method(Method::GET).with(users::profile);
-    })
-    .resource("/organizations/{id}/fee_schedule", |r| {
-        r.method(Method::GET).with(organizations::show_fee_schedule);
-        r.method(Method::POST).with(organizations::add_fee_schedule);
-    })
-    .resource("/organizations/{id}/fans", |r| {
-        r.method(Method::GET).with(organizations::search_fans);
-    })
-    .resource("/organizations/{id}/invites/{invite_id}", |r| {
-        r.method(Method::DELETE).with(organization_invites::destroy);
-    })
-    .resource("/organizations/{id}/invites", |r| {
-        r.method(Method::GET).with(organization_invites::index);
-        r.method(Method::POST).with(organization_invites::create);
-    })
-    .resource("/organizations/{id}/users", |r| {
-        r.method(Method::POST)
-            .with(organizations::add_or_replace_user);
-        r.method(Method::PUT)
-            .with(organizations::add_or_replace_user);
-        r.method(Method::GET)
-            .with(organizations::list_organization_members);
-    })
-    .resource("/organizations/{id}/users/{user_id}", |r| {
-        r.method(Method::DELETE).with(organizations::remove_user);
-    })
-    .resource("/organizations/{id}/venues", |r| {
-        r.method(Method::GET).with(venues::show_from_organizations);
-        r.method(Method::POST).with(organizations::add_venue);
-    })
-    .resource("/organizations/{id}", |r| {
-        r.method(Method::GET).with(organizations::show);
-        r.method(Method::PATCH).with(organizations::update);
-    })
-    .resource("/organizations", |r| {
-        r.method(Method::GET).with(organizations::index);
-        r.method(Method::POST).with(organizations::create);
-    })
-    .resource("/password_reset", |r| {
-        r.method(Method::POST).with(password_resets::create);
-        r.method(Method::PUT).with(password_resets::update);
-    })
-    .resource("/payment_methods", |r| {
-        r.method(Method::GET).with(payment_methods::index);
-    })
-    .resource("/regions/{id}", |r| {
-        r.method(Method::GET).with(regions::show);
-        r.method(Method::PUT).with(regions::update);
-    })
-    .resource("/regions", |r| {
-        r.method(Method::GET).with(regions::index);
-        r.method(Method::POST).with(regions::create)
-    })
-    .resource("/reports/{id}", |r| {
-        r.method(Method::GET).with(reports::get_report);
-    })
-    .resource("/status", |r| {
-        r.method(Method::GET).f(|_| HttpResponse::Ok())
-    })
-    .resource("/tickets/transfer", |r| {
-        r.method(Method::POST).with(tickets::transfer_authorization);
-    })
-    .resource("/tickets/receive", |r| {
-        r.method(Method::POST).with(tickets::receive_transfer);
-    })
-    .resource("/tickets/send", |r| {
-        r.method(Method::POST)
-            .with(tickets::send_via_email_or_phone);
-    })
-    .resource("/tickets/{id}", |r| {
-        r.method(Method::GET).with(tickets::show);
-    })
-    .resource("/tickets", |r| {
-        r.method(Method::GET).with(tickets::index);
-    })
-    .resource("/tickets/{id}/redeem", |r| {
-        r.method(Method::GET).with(tickets::show_redeemable_ticket);
-    })
-    .resource("/users/me", |r| {
-        r.method(Method::GET).with(users::current_user);
-        r.method(Method::PUT).with(users::update_current_user);
-    })
-    .resource("/users/register", |r| {
-        r.method(Method::POST).with(users::register)
-    })
-    .resource("/users/{id}/tokens", |r| {
-        r.method(Method::GET)
-            .with(users::show_push_notification_tokens_for_user_id);
-    })
-    .resource("/users/tokens", |r| {
-        r.method(Method::GET)
-            .with(users::show_push_notification_tokens);
-        r.method(Method::POST)
-            .with(users::add_push_notification_token);
-    })
-    .resource("/users/tokens/{id}", |r| {
-        r.method(Method::DELETE)
-            .with(users::remove_push_notification_token);
-    })
-    .resource("/users", |r| {
-        r.method(Method::POST).with(users::register_and_login);
-    })
-    .resource("/users/{id}", |r| {
-        r.method(Method::GET).with(users::show);
-    })
-    .resource("/user_invites", |r| {
-        r.method(Method::POST).with(user_invites::create);
-    })
-    .resource("/users/{id}/organizations", |r| {
-        r.method(Method::GET).with(users::list_organizations);
-    })
-    .resource("/venues/{id}/events", |r| {
-        r.method(Method::GET).with(events::show_from_venues);
-    })
-    .resource("/venues/{id}/organizations", |r| {
-        r.method(Method::POST).with(venues::add_to_organization);
-    })
-    .resource("/venues/{id}/toggle_privacy", |r| {
-        r.method(Method::PUT).with(venues::toggle_privacy);
-    })
-    .resource("/venues/{id}", |r| {
-        r.method(Method::GET).with(venues::show);
-        r.method(Method::PUT).with(venues::update);
-    })
-    .resource("/venues", |r| {
-        r.method(Method::GET).with(venues::index);
-        r.method(Method::POST).with(venues::create);
-    })
-    .register()
-    .default_resource(|r| {
-        r.method(Method::GET)
-            .f(|_req| HttpResponse::NotFound().json(json!({"error": "Not found"})));
-    })
+        .resource("/artists/{id}/toggle_privacy", |r| {
+            r.method(Method::PUT).with(artists::toggle_privacy);
+        })
+        .resource("/artists/{id}", |r| {
+            r.method(Method::GET).with(artists::show);
+            r.method(Method::PUT).with(artists::update);
+        })
+        .resource("/artists", |r| {
+            r.method(Method::GET).with(artists::index);
+            r.method(Method::POST).with(artists::create);
+        })
+        .resource("/auth/token", |r| r.method(Method::POST).with(auth::token))
+        .resource("/auth/token/refresh", |r| {
+            r.method(Method::POST).with(auth::token_refresh)
+        })
+        .resource("/cart", |r| {
+            r.method(Method::DELETE).with(cart::destroy);
+            r.method(Method::POST).with(cart::update_cart);
+            r.method(Method::PUT).with(cart::replace_cart);
+            r.method(Method::GET).with(cart::show);
+        })
+        .resource("/cart/checkout", |r| {
+            r.method(Method::POST).with(cart::checkout);
+        })
+        .resource("/codes/{id}", |r| {
+            r.method(Method::GET).with(codes::show);
+            r.method(Method::PUT).with(codes::update);
+            r.method(Method::DELETE).with(codes::destroy);
+        })
+        .resource("/comps/{id}", |r| {
+            r.method(Method::GET).with(comps::show);
+            r.method(Method::PATCH).with(comps::update);
+            r.method(Method::DELETE).with(comps::destroy);
+        })
+        .resource("/events", |r| {
+            r.method(Method::GET).with(events::index);
+            r.method(Method::POST).with(events::create);
+        })
+        .resource("/events/checkins", |r| {
+            r.method(Method::GET).with(events::checkins);
+        })
+        .resource("/events/{id}", |r| {
+            r.method(Method::GET).with(events::show);
+            r.method(Method::PUT).with(events::update);
+            r.method(Method::DELETE).with(events::cancel);
+        })
+        .resource("/events/{id}/artists", |r| {
+            r.method(Method::POST).with(events::add_artist);
+            r.method(Method::PUT).with(events::update_artists);
+        })
+        .resource("/events/{id}/codes", |r| {
+            r.method(Method::GET).with(events::codes);
+            r.method(Method::POST).with(codes::create);
+        })
+        .resource("/events/{id}/dashboard", |r| {
+            r.method(Method::GET).with(events::dashboard);
+        })
+        .resource("/events/{id}/guests", |r| {
+            r.method(Method::GET).with(events::guest_list);
+        })
+        .resource("/events/{id}/holds", |r| {
+            r.method(Method::POST).with(holds::create);
+            r.method(Method::GET).with(events::holds);
+        })
+        .resource("/events/{id}/interest", |r| {
+            r.method(Method::GET).with(events::list_interested_users);
+            r.method(Method::POST).with(events::add_interest);
+            r.method(Method::DELETE).with(events::remove_interest);
+        })
+        .resource("/events/{id}/publish", |r| {
+            r.method(Method::POST).with(events::publish);
+        })
+        .resource("/events/{id}/unpublish", |r| {
+            r.method(Method::POST).with(events::unpublish);
+        })
+        .resource("/events/{id}/redeem/{ticket_instance_id}", |r| {
+            r.method(Method::POST).with(events::redeem_ticket);
+        })
+        .resource("/events/{id}/tickets", |r| {
+            r.method(Method::GET).with(tickets::index);
+        })
+        .resource("/events/{id}/ticket_types", |r| {
+            r.method(Method::GET).with(ticket_types::index);
+            r.method(Method::POST).with(ticket_types::create);
+        })
+        .resource("/events/{event_id}/ticket_types/{ticket_type_id}", |r| {
+            r.method(Method::PATCH).with(ticket_types::update);
+        })
+        .resource("/external/facebook/web_login", |r| {
+            r.method(Method::POST).with(external::facebook::web_login)
+        })
+        .resource("/invitations/{id}", |r| {
+            r.method(Method::GET).with(organization_invites::view);
+        })
+        .resource("/invitations", |r| {
+            r.method(Method::POST)
+                .with(organization_invites::accept_request);
+        })
+        .resource("/holds/{id}/comps", |r| {
+            r.method(Method::GET).with(comps::index);
+            r.method(Method::POST).with(comps::create);
+        })
+        .resource("/holds/{id}/split", |r| {
+            r.method(Method::POST).with(holds::split);
+        })
+        .resource("/holds/{id}", |r| {
+            r.method(Method::PATCH).with(holds::update);
+            r.method(Method::GET).with(holds::show);
+            r.method(Method::DELETE).with(holds::destroy);
+        })
+        .resource("/orders", |r| {
+            r.method(Method::GET).with(orders::index);
+        })
+        .resource("/orders/{id}/tickets", |r| {
+            r.method(Method::GET).with(orders::tickets);
+        })
+        .resource("/orders/{id}", |r| {
+            r.method(Method::GET).with(orders::show);
+            r.method(Method::PATCH).with(orders::update);
+        })
+        .resource("/organizations/{id}/artists", |r| {
+            r.method(Method::GET).with(artists::show_from_organizations);
+            r.method(Method::POST).with(organizations::add_artist);
+        })
+        .resource("/organizations/{id}/events", |r| {
+            r.method(Method::GET).with(events::show_from_organizations);
+        })
+        .resource("/organizations/{id}/fans/{user_id}/history", |r| {
+            r.method(Method::GET).with(users::history);
+        })
+        .resource("/organizations/{id}/fans/{user_id}", |r| {
+            r.method(Method::GET).with(users::profile);
+        })
+        .resource("/organizations/{id}/fee_schedule", |r| {
+            r.method(Method::GET).with(organizations::show_fee_schedule);
+            r.method(Method::POST).with(organizations::add_fee_schedule);
+        })
+        .resource("/organizations/{id}/fans", |r| {
+            r.method(Method::GET).with(organizations::search_fans);
+        })
+        .resource("/organizations/{id}/invites/{invite_id}", |r| {
+            r.method(Method::DELETE).with(organization_invites::destroy);
+        })
+        .resource("/organizations/{id}/invites", |r| {
+            r.method(Method::GET).with(organization_invites::index);
+            r.method(Method::POST).with(organization_invites::create);
+        })
+        .resource("/organizations/{id}/users", |r| {
+            r.method(Method::POST)
+                .with(organizations::add_or_replace_user);
+            r.method(Method::PUT)
+                .with(organizations::add_or_replace_user);
+            r.method(Method::GET)
+                .with(organizations::list_organization_members);
+        })
+        .resource("/organizations/{id}/users/{user_id}", |r| {
+            r.method(Method::DELETE).with(organizations::remove_user);
+        })
+        .resource("/organizations/{id}/venues", |r| {
+            r.method(Method::GET).with(venues::show_from_organizations);
+            r.method(Method::POST).with(organizations::add_venue);
+        })
+        .resource("/organizations/{id}", |r| {
+            r.method(Method::GET).with(organizations::show);
+            r.method(Method::PATCH).with(organizations::update);
+        })
+        .resource("/organizations", |r| {
+            r.method(Method::GET).with(organizations::index);
+            r.method(Method::POST).with(organizations::create);
+        })
+        .resource("/password_reset", |r| {
+            r.method(Method::POST).with(password_resets::create);
+            r.method(Method::PUT).with(password_resets::update);
+        })
+        .resource("/payment_methods", |r| {
+            r.method(Method::GET).with(payment_methods::index);
+        })
+        .resource("/regions/{id}", |r| {
+            r.method(Method::GET).with(regions::show);
+            r.method(Method::PUT).with(regions::update);
+        })
+        .resource("/regions", |r| {
+            r.method(Method::GET).with(regions::index);
+            r.method(Method::POST).with(regions::create)
+        })
+        .resource("/reports/{id}", |r| {
+            r.method(Method::GET).with(reports::get_report);
+        })
+        .resource("/status", |r| {
+            r.method(Method::GET).f(|_| HttpResponse::Ok())
+        })
+        .resource("/tickets/transfer", |r| {
+            r.method(Method::POST).with(tickets::transfer_authorization);
+        })
+        .resource("/tickets/receive", |r| {
+            r.method(Method::POST).with(tickets::receive_transfer);
+        })
+        .resource("/tickets/send", |r| {
+            r.method(Method::POST)
+                .with(tickets::send_via_email_or_phone);
+        })
+        .resource("/tickets/{id}", |r| {
+            r.method(Method::GET).with(tickets::show);
+        })
+        .resource("/tickets", |r| {
+            r.method(Method::GET).with(tickets::index);
+        })
+        .resource("/tickets/{id}/redeem", |r| {
+            r.method(Method::GET).with(tickets::show_redeemable_ticket);
+        })
+        .resource("/users/me", |r| {
+            r.method(Method::GET).with(users::current_user);
+            r.method(Method::PUT).with(users::update_current_user);
+        })
+        .resource("/users/register", |r| {
+            r.method(Method::POST).with(users::register)
+        })
+        .resource("/users/{id}/tokens", |r| {
+            r.method(Method::GET)
+                .with(users::show_push_notification_tokens_for_user_id);
+        })
+        .resource("/users/tokens", |r| {
+            r.method(Method::GET)
+                .with(users::show_push_notification_tokens);
+            r.method(Method::POST)
+                .with(users::add_push_notification_token);
+        })
+        .resource("/users/tokens/{id}", |r| {
+            r.method(Method::DELETE)
+                .with(users::remove_push_notification_token);
+        })
+        .resource("/users", |r| {
+            r.method(Method::POST).with(users::register_and_login);
+        })
+        .resource("/users/{id}", |r| {
+            r.method(Method::GET).with(users::show);
+        })
+        .resource("/user_invites", |r| {
+            r.method(Method::POST).with(user_invites::create);
+        })
+        .resource("/users/{id}/organizations", |r| {
+            r.method(Method::GET).with(users::list_organizations);
+        })
+        .resource("/venues/{id}/events", |r| {
+            r.method(Method::GET).with(events::show_from_venues);
+        })
+        .resource("/venues/{id}/organizations", |r| {
+            r.method(Method::POST).with(venues::add_to_organization);
+        })
+        .resource("/venues/{id}/toggle_privacy", |r| {
+            r.method(Method::PUT).with(venues::toggle_privacy);
+        })
+        .resource("/venues/{id}", |r| {
+            r.method(Method::GET).with(venues::show);
+            r.method(Method::PUT).with(venues::update);
+        })
+        .resource("/venues", |r| {
+            r.method(Method::GET).with(venues::index);
+            r.method(Method::POST).with(venues::create);
+        })
+        .register()
+        .default_resource(|r| {
+            r.method(Method::GET)
+                .f(|_req| HttpResponse::NotFound().json(json!({"error": "Not found"})));
+        })
 }

--- a/db/src/models/events.rs
+++ b/db/src/models/events.rs
@@ -254,8 +254,10 @@ impl Event {
     pub fn unpublish(self, conn: &PgConnection) -> Result<Event, DatabaseError> {
         let mut errors = ValidationErrors::new();
         if self.status != EventStatus::Published {
-            let mut validation_error =
-                create_validation_error("event_must_be_published", "Event can't be un-published if it is not published");
+            let mut validation_error = create_validation_error(
+                "event_must_be_published",
+                "Event can't be un-published if it is not published",
+            );
             validation_error.add_param(Cow::from("event_id"), &self.id);
             errors.add("status", validation_error);
         }

--- a/db/src/models/events.rs
+++ b/db/src/models/events.rs
@@ -251,6 +251,35 @@ impl Event {
         )
     }
 
+    pub fn unpublish(self, conn: &PgConnection) -> Result<Event, DatabaseError> {
+        let mut errors = ValidationErrors::new();
+        if self.status != EventStatus::Published {
+            let mut validation_error =
+                create_validation_error("event_must_be_published", "Event can't be un-published if it is not published");
+            validation_error.add_param(Cow::from("event_id"), &self.id);
+            errors.add("status", validation_error);
+        }
+
+        if !errors.is_empty() {
+            return Err(errors.into());
+        }
+
+        let update_fields = EventEditableAttributes {
+            publish_date: Some(None),
+            ..Default::default()
+        };
+        diesel::update(&self)
+            .set((
+                update_fields,
+                events::status.eq(EventStatus::Draft),
+                events::updated_at.eq(dsl::now),
+            ))
+            .execute(conn)
+            .to_db_error(ErrorCode::UpdateError, "Could not un-publish record")?;
+
+        Event::find(self.id, conn)
+    }
+
     pub fn publish(self, conn: &PgConnection) -> Result<Event, DatabaseError> {
         if self.status == EventStatus::Published {
             return Event::find(self.id, conn);

--- a/db/tests/unit/events.rs
+++ b/db/tests/unit/events.rs
@@ -250,6 +250,60 @@ fn publish_change_publish_date() {
 }
 
 #[test]
+fn unpublish() {
+    //create event
+    let project = TestProject::new();
+    let venue = project.create_venue().finish();
+
+    let user = project.create_user().finish();
+    let organization = project
+        .create_organization()
+        .with_member(&user, Roles::OrgOwner)
+        .finish();
+    let event = project
+        .create_event()
+        .with_status(EventStatus::Draft)
+        .with_name("NewEvent".into())
+        .with_organization(&organization)
+        .with_venue(&venue)
+        .finish();
+
+    assert_eq!(event.status, EventStatus::Draft);
+
+    let event = event.publish(project.get_connection()).unwrap();
+
+    assert_eq!(event.status, EventStatus::Published);
+    assert!(event.publish_date.is_some());
+
+    let event = event.unpublish(project.get_connection()).unwrap();
+    assert_eq!(event.status, EventStatus::Draft);
+    assert!(event.publish_date.is_none());
+}
+
+#[test]
+fn cannot_unpublish_unpublished_event() {
+    //create event
+    let project = TestProject::new();
+    let venue = project.create_venue().finish();
+
+    let user = project.create_user().finish();
+    let organization = project
+        .create_organization()
+        .with_member(&user, Roles::OrgOwner)
+        .finish();
+    let event = project
+        .create_event()
+        .with_status(EventStatus::Draft)
+        .with_name("NewEvent".into())
+        .with_organization(&organization)
+        .with_venue(&venue)
+        .finish();
+
+    assert_eq!(event.status, EventStatus::Draft);
+    assert!(event.unpublish(project.get_connection()).is_err());
+}
+
+#[test]
 fn cancel() {
     //create event
     let project = TestProject::new();

--- a/integration-tests/bigneon-tests.postman_collection.json
+++ b/integration-tests/bigneon-tests.postman_collection.json
@@ -3759,6 +3759,222 @@
 							"response": []
 						},
 						{
+							"name": "OrgMember  - Create Event To Un-Publish",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "91fe0a26-e6a0-437a-a7e7-834185ecf193",
+										"exec": [
+											"pm.test(\"should be 201\", function() {",
+											"    pm.response.to.have.status(201);",
+											"})",
+											"",
+											"pm.environment.set(\"unpublish_event_id\", JSON.parse(responseBody).id);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{org_member_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"name\": \"It's my party - To Un-Publish\",\n    \"organization_id\": \"{{last_org_id}}\",\n    \"venue_id\": \"{{last_venue_id}}\",\n    \"event_start\": \"2020-11-13T12:00:00\",\n    \"publish_date\": \"2019-01-01T00:00:00\",\n    \"promo_image_url\": \"http://localhost/noimg.png\"\n}"
+								},
+								"url": {
+									"raw": "http://{{server}}/events",
+									"protocol": "http",
+									"host": [
+										"{{server}}"
+									],
+									"path": [
+										"events"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "OrgMember  - Publish Event To Un-Publish",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c5e62cfa-62d4-44b3-94cb-e6946bb423c2",
+										"exec": [
+											"pm.test(\"should be 200\", function() {",
+											"    pm.response.to.have.status(200);",
+											"})",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{org_member_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "http://{{server}}/events/{{unpublish_event_id}}/publish",
+									"protocol": "http",
+									"host": [
+										"{{server}}"
+									],
+									"path": [
+										"events",
+										"{{unpublish_event_id}}",
+										"publish"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "OrgMember  - Un-Publish Event",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c5e62cfa-62d4-44b3-94cb-e6946bb423c2",
+										"exec": [
+											"pm.test(\"should be 200\", function() {",
+											"    pm.response.to.have.status(200);",
+											"})",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{org_member_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "http://{{server}}/events/{{unpublish_event_id}}/unpublish",
+									"protocol": "http",
+									"host": [
+										"{{server}}"
+									],
+									"path": [
+										"events",
+										"{{unpublish_event_id}}",
+										"unpublish"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "OrgMember  - Un-Publish Un-Published Event - 422",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c5e62cfa-62d4-44b3-94cb-e6946bb423c2",
+										"exec": [
+											"pm.test(\"should be 422\", function() {",
+											"    pm.response.to.have.status(422);",
+											"})"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{org_member_token}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "http://{{server}}/events/{{unpublish_event_id}}/unpublish",
+									"protocol": "http",
+									"host": [
+										"{{server}}"
+									],
+									"path": [
+										"events",
+										"{{unpublish_event_id}}",
+										"unpublish"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "BoxOffice  - Publish Event - 401",
 							"event": [
 								{

--- a/integration-tests/bigneon-tests.postman_collection.json
+++ b/integration-tests/bigneon-tests.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "8b249643-ca19-4f12-a805-d06875366c88",
+		"_postman_id": "6faad884-53b6-4674-9dc1-1f59e453aec7",
 		"name": "bigneon-tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -18,7 +18,7 @@ apt-get install npm
 npm config set strict-ssl false
 npm install -g newman
 
-newman run ../integration-tests/bigneon-tests.postman_collection.json -e ../integration-tests/travis.postman_environment.json
+newman run --timeout-request 30000 ../integration-tests/bigneon-tests.postman_collection.json -e ../integration-tests/travis.postman_environment.json
 NEWMAN_EXIT_CODE=$?
 kill -s SIGTERM $SERVER_PID
 if [ $NEWMAN_EXIT_CODE -ne 0 ]


### PR DESCRIPTION
Closes #832
Added unpublish endpoint `events/{id}/unpublish` currently the only limitation is that the event must be published. We can get more specific with things like, if tickets have been sold, then the event must be cancelled and not unpublished.
Also attempt to fix the postman test issues with a longer timeout.