### PR TITLE
Add localized event time

### DIFF
--- a/api/src/controllers/events.rs
+++ b/api/src/controllers/events.rs
@@ -153,6 +153,7 @@ pub fn index(
         is_external: bool,
         external_url: Option<String>,
         user_is_interested: bool,
+        localized_times: EventLocalizedTimes,
     }
 
     let mut venue_ids: Vec<Uuid> = events
@@ -179,8 +180,10 @@ pub fn index(
     };
 
     let results = events.into_iter().fold(Vec::new(), |mut results, event| {
+        let venue = event.venue_id.and_then(|v| Some(venue_map[&v].clone()));
+        let localized_times = event.get_all_localized_times(&venue);
         results.push(EventVenueEntry {
-            venue: event.venue_id.and_then(|v| Some(venue_map[&v].clone())),
+            venue,
             id: event.id,
             name: event.name,
             organization_id: event.organization_id,
@@ -203,6 +206,7 @@ pub fn index(
                 .get(&event.id)
                 .map(|i| i.to_owned())
                 .unwrap_or(false),
+            localized_times,
         });
         results
     });
@@ -233,6 +237,7 @@ pub fn show(
     let fee_schedule = FeeSchedule::find(organization.fee_schedule_id, connection)?;
 
     let venue = event.venue(connection)?;
+    let localized_times = event.get_all_localized_times(&venue);
     let event_artists = EventArtist::find_all_from_event(event.id, connection)?;
     let total_interest = EventInterest::total_interest(event.id, connection)?;
     let user_interest = match user {
@@ -254,7 +259,7 @@ pub fn show(
                     &http_request,
                     None,
                     None,
-                )
+                );
             }
         }
     }
@@ -332,6 +337,7 @@ pub fn show(
         external_url: Option<String>,
         override_status: Option<EventOverrideStatus>,
         limited_tickets_remaining: Vec<TicketsRemaining>,
+        localized_times: EventLocalizedTimes,
     }
 
     Ok(HttpResponse::Ok().json(&R {
@@ -366,6 +372,7 @@ pub fn show(
         external_url: event.external_url,
         override_status: event.override_status,
         limited_tickets_remaining,
+        localized_times,
     }))
 }
 
@@ -424,17 +431,17 @@ pub fn redeem_ticket(
             //Redeem ticket on chain
             let asset = Asset::find(ticket.asset_id, connection)?;
             match asset.blockchain_asset_id {
-                    Some(a) => {
-                        let wallet = Wallet::find(ticket.wallet_id, connection)?;
-                        state.config.tari_client.modify_asset_redeem_token(&wallet.secret_key, &wallet.public_key,
-                                                                           &a,
-                                                                           vec![ticket.token_id as u64],
-                        )?;
+                Some(a) => {
+                    let wallet = Wallet::find(ticket.wallet_id, connection)?;
+                    state.config.tari_client.modify_asset_redeem_token(&wallet.secret_key, &wallet.public_key,
+                                                                       &a,
+                                                                       vec![ticket.token_id as u64],
+                    )?;
 
-                        Ok(HttpResponse::Ok().json(redeemable))
-                    },
-                    None => Ok(HttpResponse::BadRequest().json(json!({ "error": "Could not complete this checkout because the asset has not been assigned on the blockchain.".to_string()}))),
+                    Ok(HttpResponse::Ok().json(redeemable))
                 }
+                None => Ok(HttpResponse::BadRequest().json(json!({ "error": "Could not complete this checkout because the asset has not been assigned on the blockchain.".to_string()}))),
+            }
         }
         RedeemResults::TicketAlreadyRedeemed => Ok(HttpResponse::Conflict()
             .json(json!({"error": "Ticket has already been redeemed.".to_string()}))),
@@ -471,8 +478,9 @@ pub fn show_from_organizations(
 
 #[derive(Deserialize)]
 pub struct DashboardParameters {
-    start_utc: Option<NaiveDate>, // Defaults to 29 days ago if not provided
-    end_utc: Option<NaiveDate>,   // Defaults to today if not provided
+    start_utc: Option<NaiveDate>,
+    // Defaults to 29 days ago if not provided
+    end_utc: Option<NaiveDate>, // Defaults to today if not provided
 }
 
 #[derive(Deserialize, Serialize)]

--- a/api/tests/functional/base/events.rs
+++ b/api/tests/functional/base/events.rs
@@ -710,6 +710,7 @@ pub fn expected_show_json(
         external_url: Option<String>,
         override_status: Option<EventOverrideStatus>,
         limited_tickets_remaining: Vec<TicketsRemaining>,
+        localized_times: EventLocalizedTimes,
     }
 
     let fee_schedule = FeeSchedule::find(organization.fee_schedule_id, connection).unwrap();
@@ -731,7 +732,7 @@ pub fn expected_show_json(
             );
         }
     }
-
+    let localized_times: EventLocalizedTimes = event.get_all_localized_times(&Some(venue.clone()));
     serde_json::to_string(&R {
         id: event.id,
         name: event.name,
@@ -764,6 +765,7 @@ pub fn expected_show_json(
         external_url: event.external_url,
         override_status: event.override_status,
         limited_tickets_remaining: no_tickets_remaining,
+        localized_times,
     })
     .unwrap()
 }

--- a/api/tests/functional/events.rs
+++ b/api/tests/functional/events.rs
@@ -264,6 +264,7 @@ pub fn index_search_with_filter() {
         .with_event_start(NaiveDate::from_ymd(2022, 7, 8).and_hms(9, 10, 11))
         .finish();
 
+    let localized_times = event.get_all_localized_times(&None);
     let expected_events = vec![EventVenueEntry {
         id: event.id,
         name: event.name,
@@ -285,6 +286,7 @@ pub fn index_search_with_filter() {
         is_external: false,
         external_url: None,
         user_is_interested: false,
+        localized_times,
     }];
 
     let test_request = TestRequest::create_with_uri("/events?query=NewEvent1");
@@ -956,6 +958,7 @@ struct EventVenueEntry {
     is_external: bool,
     external_url: Option<String>,
     user_is_interested: bool,
+    localized_times: EventLocalizedTimes,
 }
 
 fn event_venue_entry(
@@ -964,6 +967,7 @@ fn event_venue_entry(
     user: Option<User>,
     connection: &PgConnection,
 ) -> EventVenueEntry {
+    let localized_times = event.get_all_localized_times(&Some(venue.clone()));
     EventVenueEntry {
         id: event.id,
         name: event.name.clone(),
@@ -987,5 +991,6 @@ fn event_venue_entry(
         user_is_interested: user
             .map(|u| EventInterest::user_interest(event.id, u.id, connection).unwrap())
             .unwrap_or(false),
+        localized_times,
     }
 }

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -28,6 +28,7 @@ hex = "0.3.2"
 rand = "0.5"
 uuid = { version = "0.6", features = ["serde", "v4"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.4"
 argon2rs = "0.2"
 itertools = "0.7"
 log = "0.4"

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -16,6 +16,7 @@ extern crate diesel;
 extern crate argon2rs;
 extern crate backtrace;
 extern crate chrono;
+extern crate chrono_tz;
 extern crate hex;
 extern crate itertools;
 //#[macro_use]


### PR DESCRIPTION
Adds a `localized_times` key to event responses. If the `Venue` has a `timezone` value it will format the `event_start`, `event_end` and `door_time` fields to the timezone for the venue.