### PR TITLE
Improved error message if event is still a Draft

### DIFF
--- a/api/src/controllers/cart.rs
+++ b/api/src/controllers/cart.rs
@@ -71,9 +71,8 @@ pub fn update_cart(
 
     for order_item in &order_items {
         if !Dbticket_types::is_event_not_draft(&order_item.ticket_type_id, connection)? {
-            return Ok(
-                HttpResponse::BadRequest().json(json!({"error": "Event is invalid.".to_string()}))
-            );
+            return Ok(HttpResponse::BadRequest()
+                .json(json!({"error": "Event has not been published.".to_string()})));
         }
     }
     cart.update_quantities(&order_items, box_office_pricing, false, connection)?;
@@ -131,9 +130,8 @@ pub fn replace_cart(
 
     for order_item in &order_items {
         if !Dbticket_types::is_event_not_draft(&order_item.ticket_type_id, connection)? {
-            return Ok(
-                HttpResponse::BadRequest().json(json!({"error": "Event is invalid.".to_string()}))
-            );
+            return Ok(HttpResponse::BadRequest()
+                .json(json!({"error": "Event has not been published.".to_string()})));
         }
     }
 


### PR DESCRIPTION
### Closes Issues:
Closes #876 
### Description:
The backend is working as it should - i.e. not selling tickets to draft events.
I've improved the error message, but I will also make it harder for the users to get to this point.
Related to big-neon/bn-web#951

## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
