### PR TITLE
Marketing contacts fix: Enqueue create event list domain action for event publish

### DIFF
--- a/api/src/controllers/events.rs
+++ b/api/src/controllers/events.rs
@@ -16,8 +16,6 @@ use std::collections::HashMap;
 use utils::marketing_contacts;
 use uuid::Uuid;
 
-const LOG_TARGET: &'static str = "bigneon::controllers::events";
-
 #[derive(Deserialize)]
 pub struct SearchParameters {
     #[serde(default, deserialize_with = "deserialize_unless_blank")]
@@ -428,17 +426,8 @@ pub fn publish(
 
     // TODO: Remove domain action and replace with domain event EventPublished
     //       once domain events are ready #DomainEvents
-    let _ = marketing_contacts::BulkEventFanListImportAction::new(event.id)
-        .enqueue(conn)
-        .or_else(|err| {
-            jlog!(
-                log::Level::Error,
-                LOG_TARGET,
-                "Failure when enqueing domain action MarketContactsCreateEventList",
-                { "innerError": format!("{}", err) }
-            );
-            Err(err)
-        });
+    let _ = marketing_contacts::CreateEventMarketingListAction::new(event.id)
+        .enqueue(conn)?;
 
     Ok(HttpResponse::Ok().finish())
 }

--- a/api/src/controllers/events.rs
+++ b/api/src/controllers/events.rs
@@ -426,8 +426,7 @@ pub fn publish(
 
     // TODO: Remove domain action and replace with domain event EventPublished
     //       once domain events are ready #DomainEvents
-    let _ = marketing_contacts::CreateEventMarketingListAction::new(event.id)
-        .enqueue(conn)?;
+    let _ = marketing_contacts::CreateEventMarketingListAction::new(event.id).enqueue(conn)?;
 
     Ok(HttpResponse::Ok().finish())
 }


### PR DESCRIPTION
Related to: #857 

### Description:

Enqueue the create list action when events are published. The create event list executor is idempotent and will ensure that 1) the event has the right sendgrid list id attached, 2) the repeating contact bulk import domain action is created for the event if it doesn't already exist 

## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
