### PR TITLE
Added order_item_id to event guest_list response

### DIFF
--- a/db/src/models/redeemable_ticket.rs
+++ b/db/src/models/redeemable_ticket.rs
@@ -13,6 +13,8 @@ pub struct RedeemableTicket {
     pub user_id: Option<Uuid>,
     #[sql_type = "dUuid"]
     pub order_id: Uuid,
+    #[sql_type = "dUuid"]
+    pub order_item_id: Uuid,
     #[sql_type = "BigInt"]
     pub price_in_cents: i64,
     #[sql_type = "Nullable<Text>"]

--- a/db/src/models/ticket_instances.rs
+++ b/db/src/models/ticket_instances.rs
@@ -577,6 +577,7 @@ impl TicketInstance {
                 ticket_types::name,
                 sql::<Nullable<dUuid>>("users.id as user_id"),
                 order_items::order_id,
+                sql::<dUuid>("order_items.id as order_item_id"),
                 sql::<BigInt>(
                     "cast(unit_price_in_cents +
                     coalesce((

--- a/db/src/queries/retrieve_guest_list.sql
+++ b/db/src/queries/retrieve_guest_list.sql
@@ -4,6 +4,7 @@ SELECT ti.id,
        u.last_name   AS last_name,
        u.id          AS user_id,
        oi.order_id   AS order_id,
+       oi.id         AS order_item_id,
        cast(oi.unit_price_in_cents + coalesce((
           select sum(unit_price_in_cents)
           from order_items


### PR DESCRIPTION
### Closes Issues:
Closes #898 
### Description:
To process refunds we need the order_item_id in the guest list response
## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
