### PR TITLE
Return redeem_key if event start within 24 hours

### DIFF
--- a/db/src/models/ticket_instances.rs
+++ b/db/src/models/ticket_instances.rs
@@ -645,8 +645,9 @@ impl TicketInstance {
             .first::<RedeemableTicket>(conn)
             .to_db_error(ErrorCode::QueryError, "Unable to load ticket")?;
 
-        if ticket_data.redeem_date.is_some()
-            && ticket_data.redeem_date.unwrap() > Utc::now().naive_utc()
+        // Remove redeem key from results unless it's 24 hours before event start
+        if ticket_data.event_start.is_none()
+            || ticket_data.event_start.unwrap() - Duration::hours(24) > Utc::now().naive_utc()
         {
             ticket_data.redeem_key = None; //Redeem key not available yet. Should this be an error?
         }


### PR DESCRIPTION
### Closes Issues:
Closes #960 

### Description:

- If there's no event_start date the redeem key is not returned
- If it's more than 24 hours before the event start date, the redeem key is not returned

## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
