### PR TITLE
Modify post event cadence to capture events ending in new period

### DIFF
--- a/db/src/models/organizations.rs
+++ b/db/src/models/organizations.rs
@@ -306,13 +306,19 @@ impl Organization {
         let now = timezone.from_utc_datetime(&Utc::now().naive_utc());
         let today = timezone.ymd(now.year(), now.month(), now.day()).and_hms(0, 0, 0);
 
+        let start_hour = if self.settlement_type == SettlementTypes::PostEvent {
+            3
+        } else {
+            0
+        };
+
         // If this is a normal week long settlement period, set it to start on the following Monday
         // Else set as number of days from today
         if let Some(settlement_period) = settlement_period_in_days {
             let next_period = today.naive_local() + Duration::days(settlement_period as i64);
             let next_date = timezone
                 .ymd(next_period.year(), next_period.month(), next_period.day())
-                .and_hms(0, 0, 0)
+                .and_hms(start_hour, 0, 0)
                 .naive_utc();
 
             Ok(next_date)
@@ -320,7 +326,8 @@ impl Organization {
             let next_date = today.naive_utc()
                 + Duration::days(
                     DEFAULT_SETTLEMENT_PERIOD_IN_DAYS - today.naive_local().weekday().num_days_from_monday() as i64,
-                );
+                )
+                + Duration::hours(start_hour as i64);
 
             Ok(next_date)
         }

--- a/db/tests/unit/organizations.rs
+++ b/db/tests/unit/organizations.rs
@@ -193,15 +193,17 @@ fn next_settlement_date() {
     let pt_timezone: Tz = "America/Los_Angeles".parse().unwrap();
     let now = pt_timezone.from_utc_datetime(&Utc::now().naive_utc());
     let pt_today = pt_timezone.ymd(now.year(), now.month(), now.day()).and_hms(0, 0, 0);
-    let expected_pt =
-        pt_today.naive_utc() + Duration::days(7 - pt_today.naive_local().weekday().num_days_from_monday() as i64);
+    let expected_pt = pt_today.naive_utc()
+        + Duration::days(7 - pt_today.naive_local().weekday().num_days_from_monday() as i64)
+        + Duration::hours(3);
     let sa_timezone: Tz = "Africa/Johannesburg".parse().unwrap();
     let now = sa_timezone.from_utc_datetime(&Utc::now().naive_utc());
     let sa_today = sa_timezone.ymd(now.year(), now.month(), now.day()).and_hms(0, 0, 0);
-    let expected_sa =
-        sa_today.naive_utc() + Duration::days(7 - sa_today.naive_local().weekday().num_days_from_monday() as i64);
+    let expected_sa = sa_today.naive_utc()
+        + Duration::days(7 - sa_today.naive_local().weekday().num_days_from_monday() as i64)
+        + Duration::hours(3);
 
-    // Default behavior no timezone, upcoming Monday 12:00 AM PT
+    // Default behavior no timezone, upcoming Monday 3:00 AM PT
     assert_eq!(organization.next_settlement_date(None).unwrap(), expected_pt);
 
     // Override organization timezone to SA
@@ -219,6 +221,8 @@ fn next_settlement_date() {
     assert_eq!(organization.next_settlement_date(None).unwrap(), expected_sa);
 
     // Switch to rolling which always uses PT
+    let expected_pt =
+        pt_today.naive_utc() + Duration::days(7 - pt_today.naive_local().weekday().num_days_from_monday() as i64);
     let organization = organization
         .update(
             OrganizationEditableAttributes {
@@ -233,6 +237,9 @@ fn next_settlement_date() {
     assert_eq!(organization.next_settlement_date(None).unwrap(), expected_pt);
 
     // Override organization timezone to PT and switch back to PostEvent
+    let expected_pt = pt_today.naive_utc()
+        + Duration::days(7 - pt_today.naive_local().weekday().num_days_from_monday() as i64)
+        + Duration::hours(3);
     let organization = organization
         .update(
             OrganizationEditableAttributes {
@@ -248,7 +255,7 @@ fn next_settlement_date() {
     assert_eq!(organization.next_settlement_date(None).unwrap(), expected_pt);
 
     // Using a passed in settlement period
-    let expected_pt = pt_today.naive_utc() + Duration::days(1);
+    let expected_pt = pt_today.naive_utc() + Duration::days(1) + Duration::hours(3);
     assert_eq!(organization.next_settlement_date(Some(1)).unwrap(), expected_pt);
 
     let organization = organization
@@ -262,7 +269,7 @@ fn next_settlement_date() {
             connection,
         )
         .unwrap();
-    let expected_sa = sa_today.naive_utc() + Duration::days(1);
+    let expected_sa = sa_today.naive_utc() + Duration::days(1) + Duration::hours(3);
     assert_eq!(organization.next_settlement_date(Some(1)).unwrap(), expected_sa);
 
     // Rolling with passed in settlement period
@@ -277,6 +284,7 @@ fn next_settlement_date() {
             connection,
         )
         .unwrap();
+    let expected_pt = pt_today.naive_utc() + Duration::days(1);
     assert_eq!(organization.next_settlement_date(Some(1)).unwrap(), expected_pt);
 }
 


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1145151428687738/1146071532050972

### Description:
This PR simply changes the post event settlement report cadence so instead of running at midnight local organization timezone they run at 3 AM local organization timezone. This allows it to include events that end that night prior. Previously if the event ended at Sunday at 1 AM it wouldn't be included until the subsequent report. This is a changed based on feedback from the team and the meeting we had today.

### Examples
I only tested the cadence here as the other logic was not changed. Set my machine to the times when the job was supposed to run and then it ran and generated a settlement report with a given timeframe and a new record for the subsequent domain action. In each I list the domain action created by the regeneration job, the subsequent action created when that job is run, and its timeframe.

#### Post Event Normal PT

```
bigneon=# select * from domain_actions where domain_action_type like 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 c1ce6302-00f3-4a34-a0ef-1f5a90714e9f |                 | ProcessSettlementReport |                            | {}      | Organizations | b65bc5cc-5ef4-4dad-b366-167b000f1ab2 | 2019-11-18 11:00:00 | 2019-11-18 11:15:00.000003 |                   |             0 |                 3 | Pending |                     | 2019-11-18 10:59:30.000016 | 2019-11-13 20:53:42.638819 | 2019-11-13 20:53:42.638819
(1 row)

bigneon=# select * from domain_actions where domain_action_type like 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 1b749613-e0a2-4b9e-baae-8e4ff725a1fe |                 | ProcessSettlementReport |                            | {}      | Organizations | b65bc5cc-5ef4-4dad-b366-167b000f1ab2 | 2019-11-25 11:00:00 | 2019-11-25 11:15:00.000277 |                   |             0 |                 3 | Pending |                     | 2019-11-25 10:59:30.000282 | 2019-11-18 11:00:09.456048 | 2019-11-18 11:00:09.456048
(1 row)

bigneon=# select start_time, end_time from settlements;
     start_time      |      end_time       
---------------------+---------------------
 2019-11-11 11:00:00 | 2019-11-18 10:59:59
(1 row)
```
11/11 3 AM PT -> 11/18 3 AM PT for the job run on 11/18 at 3 AM PT.

#### Rolling Normal PT

```
bigneon=# select * from domain_actions where domain_action_type like 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 d5945878-2790-414a-825e-a0b04daa3504 |                 | ProcessSettlementReport |                            | {}      | Organizations | b65bc5cc-5ef4-4dad-b366-167b000f1ab2 | 2019-11-18 08:00:00 | 2019-11-18 08:15:00.000003 |                   |             0 |                 3 | Pending |                     | 2019-11-18 07:59:30.000016 | 2019-11-13 21:01:09.270931 | 2019-11-13 21:01:09.270931
(1 row)

bigneon=# select * from domain_actions where domain_action_type like 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 0d517a61-dc57-4f61-b54a-43ed0623bde1 |                 | ProcessSettlementReport |                            | {}      | Organizations | b65bc5cc-5ef4-4dad-b366-167b000f1ab2 | 2019-11-25 08:00:00 | 2019-11-25 08:15:00.000004 |                   |             0 |                 3 | Pending |                     | 2019-11-25 07:59:30.000007 | 2019-11-18 08:00:00.087512 | 2019-11-18 08:00:00.087512
(1 row)

bigneon=# select start_time, end_time from settlements;
     start_time      |      end_time       
---------------------+---------------------
 2019-11-11 08:00:00 | 2019-11-18 07:59:59
(1 row)
```
11/11 12 AM PT -> 11/18 12 AM PT for the job run on 11/18 at 12 AM PT.

#### Post Event with 1 Day Period PT

```
bigneon=# select * from domain_actions where domain_action_type like 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 ce731c43-f6ca-4644-aeb8-551f534cbc65 |                 | ProcessSettlementReport |                            | {}      | Organizations | b65bc5cc-5ef4-4dad-b366-167b000f1ab2 | 2019-11-14 11:00:00 | 2019-11-14 11:15:00.000002 |                   |             0 |                 3 | Pending |                     | 2019-11-14 10:59:30.000014 | 2019-11-13 21:05:37.745195 | 2019-11-13 21:05:37.745195
(1 row)

bigneon=# select * from domain_actions where domain_action_type like 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 ca369908-f582-4a81-883f-53ef99209ec6 |                 | ProcessSettlementReport |                            | {}      | Organizations | b65bc5cc-5ef4-4dad-b366-167b000f1ab2 | 2019-11-15 11:00:00 | 2019-11-15 11:15:00.000003 |                   |             0 |                 3 | Pending |                     | 2019-11-15 10:59:30.000007 | 2019-11-14 11:00:00.653171 | 2019-11-14 11:00:00.653171
(1 row)

bigneon=# select start_time, end_time from settlements;
     start_time      |      end_time       
---------------------+---------------------
 2019-11-13 11:00:00 | 2019-11-14 10:59:59
(1 row)
```
11/13 3 AM PT -> 11/14 3 AM PT for the job run on 11/14 at 3 AM PT.

#### Rolling with 1 Day Period 

```
bigneon=# select * from domain_actions where domain_action_type like 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 cc479889-73ea-4f40-a7dc-d9a78f308584 |                 | ProcessSettlementReport |                            | {}      | Organizations | b65bc5cc-5ef4-4dad-b366-167b000f1ab2 | 2019-11-14 08:00:00 | 2019-11-14 08:15:00.000002 |                   |             0 |                 3 | Pending |                     | 2019-11-14 07:59:30.000013 | 2019-11-13 21:03:38.265198 | 2019-11-13 21:03:38.265198
(1 row)

bigneon=# select * from domain_actions where domain_action_type like 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 2008c39e-07f0-4fa4-9304-13e84daa675a |                 | ProcessSettlementReport |                            | {}      | Organizations | b65bc5cc-5ef4-4dad-b366-167b000f1ab2 | 2019-11-15 08:00:00 | 2019-11-15 08:15:00.000003 |                   |             0 |                 3 | Pending |                     | 2019-11-15 07:59:30.000006 | 2019-11-14 08:00:09.797235 | 2019-11-14 08:00:09.797235
(1 row)

bigneon=# select start_time, end_time from settlements;
     start_time      |      end_time       
---------------------+---------------------
 2019-11-13 08:00:00 | 2019-11-14 07:59:59
(1 row)
```
11/13 12 AM PT -> 11/14 12 AM PT for the job run on 11/14 at 12 AM PT.

#### Post Event SA Normal
```
bigneon=# select * from domain_actions where domain_action_type like 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 37e7f0dd-e304-428f-a835-9e110163e83e |                 | ProcessSettlementReport |                            | {}      | Organizations | b65bc5cc-5ef4-4dad-b366-167b000f1ab2 | 2019-11-18 01:00:00 | 2019-11-18 01:15:00.000003 |                   |             0 |                 3 | Pending |                     | 2019-11-18 01:01:00.668321 | 2019-11-13 21:27:38.081319 | 2019-11-18 01:00:00.672439
(1 row)

bigneon=# select * from domain_actions where domain_action_type like 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 d3902db0-5cec-4d79-8586-d160c873c6fd |                 | ProcessSettlementReport |                            | {}      | Organizations | b65bc5cc-5ef4-4dad-b366-167b000f1ab2 | 2019-11-25 01:00:00 | 2019-11-25 01:15:00.000003 |                   |             0 |                 3 | Pending |                     | 2019-11-25 00:59:30.000006 | 2019-11-18 01:00:00.672439 | 2019-11-18 01:00:00.672439
(1 row)

bigneon=# select start_time, end_time from settlements;
     start_time      |      end_time       
---------------------+---------------------
 2019-11-11 01:00:00 | 2019-11-18 00:59:59
(1 row)
```

11/11 3 AM SA -> 11/18 3 AM SA for the job run on 11/18 at 3 AM SA.

#### Rolling Event SA Normal
```
bigneon=# select * from domain_actions where domain_action_type like 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 4089c4d9-dc95-46ff-8b4c-1a69a8ea8a1a |                 | ProcessSettlementReport |                            | {}      | Organizations | b65bc5cc-5ef4-4dad-b366-167b000f1ab2 | 2019-11-18 08:00:00 | 2019-11-18 08:15:00.000002 |                   |             0 |                 3 | Pending |                     | 2019-11-18 07:59:30.000014 | 2019-11-13 21:30:45.396616 | 2019-11-13 21:30:45.396616
(1 row)

bigneon=# select * from domain_actions where domain_action_type like 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 d8391b7b-24d0-485d-ba26-20d42bb385a0 |                 | ProcessSettlementReport |                            | {}      | Organizations | b65bc5cc-5ef4-4dad-b366-167b000f1ab2 | 2019-11-25 08:00:00 | 2019-11-25 08:15:00.000003 |                   |             0 |                 3 | Pending |                     | 2019-11-25 07:59:30.000006 | 2019-11-18 08:00:00.221962 | 2019-11-18 08:00:00.221962
(1 row)

bigneon=# select start_time, end_time from settlements;
     start_time      |      end_time       
---------------------+---------------------
 2019-11-11 08:00:00 | 2019-11-18 07:59:59
(1 row)
```

11/11 12 AM PT -> 11/18 12 AM PT for the job run on 11/18 at 12 AM PT.

## Release Details:
Given the settlement reports are run as domain actions given they need to be run at specific times depending upon the organizations they need to be recreated for the environment.

First we need to remove any pending domain action:
```
delete from domain_actions where domain_action_type like 'ProcessSettlementReport' and status = 'Pending';
```

Next we need to run the CLI command to regenerate the next one set to run:
```
cargo run --bin api-cli schedule-missing-domain-actions
```

### Migrations
 * No Migrations

### Environment Variables
 * No change
