### PR TITLE
Use assert_equiv in the unit::events::find_all_events_for_organization

### DIFF
--- a/db/src/models/events.rs
+++ b/db/src/models/events.rs
@@ -1917,7 +1917,7 @@ pub struct DisplayEvent {
     pub slug: String,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct EventSummaryResult {
     pub id: Uuid,
     pub name: String,
@@ -1954,6 +1954,12 @@ pub struct EventSummaryResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eligible_for_deletion: Option<bool>,
     pub extra_admin_data: Option<Value>,
+}
+
+impl PartialOrd for EventSummaryResult {
+    fn partial_cmp(&self, other: &EventSummaryResult) -> Option<Ordering> {
+        Some(self.id.cmp(&other.id))
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, QueryableByName)]

--- a/db/tests/unit/events.rs
+++ b/db/tests/unit/events.rs
@@ -2181,7 +2181,7 @@ fn find_all_events_for_organization() {
     // No filter on past or upcoming returns all events
     let events =
         Event::find_all_events_for_organization(organization.id, None, None, false, 0, 100, connection).unwrap();
-    assert_eq!(
+    assert_equiv!(
         events.data,
         vec![
             past_event.summary(connection).unwrap(),


### PR DESCRIPTION
### Description:
The `unit::events::find_all_events_for_organization` was intermittently failing, this should fix that problem by using `assert_equiv` on the vec of EventSummaryResult
## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
