### PR TITLE
Adjust settlement logic to allow for free tickets with fees

### DIFF
--- a/db/functions/process_settlement_for_event.sql
+++ b/db/functions/process_settlement_for_event.sql
@@ -37,7 +37,6 @@ AND oi.item_type <> 'CreditCardFees'
 AND o.settlement_id IS NULL
 AND o.status = 'Paid'
 AND oi.parent_id IS NULL
-AND (oi.unit_price_in_cents + COALESCE(oi_promo_code.unit_price_in_cents, 0)) > 0
 AND o.box_office_pricing IS FALSE;
 
 -- Add refund items to the order items temp table
@@ -130,9 +129,9 @@ FROM (
   -- Filter out any records where the sum of their quantities is 0
   -- Negative indicates a refund settlement adjustment, positive purchases
   HAVING
-    SUM(online_sold_quantity) <> 0
+    (SUM(online_sold_quantity) <> 0 AND face_value_in_cents > 0)
   OR
-    SUM(fee_sold_quantity) <> 0
+    (SUM(fee_sold_quantity) <> 0 AND revenue_share_value_in_cents > 0)
 ;
 
 -- Update associated orders as part of this settlement

--- a/db/src/models/order_items.rs
+++ b/db/src/models/order_items.rs
@@ -36,8 +36,8 @@ pub struct OrderItem {
     pub parent_id: Option<Uuid>,
     pub hold_id: Option<Uuid>,
     pub code_id: Option<Uuid>,
-    pub(crate) company_fee_in_cents: i64,
-    pub(crate) client_fee_in_cents: i64,
+    pub company_fee_in_cents: i64,
+    pub client_fee_in_cents: i64,
     pub refunded_quantity: i64,
 }
 

--- a/db/src/test/builders/fee_schedule_builder.rs
+++ b/db/src/test/builders/fee_schedule_builder.rs
@@ -21,6 +21,11 @@ impl<'a> FeeScheduleBuilder<'a> {
             self.name,
             vec![
                 NewFeeScheduleRange {
+                    min_price_in_cents: 0,
+                    company_fee_in_cents: 0,
+                    client_fee_in_cents: 0,
+                },
+                NewFeeScheduleRange {
                     min_price_in_cents: 50,
                     company_fee_in_cents: 4,
                     client_fee_in_cents: 6,

--- a/db/tests/unit/orders.rs
+++ b/db/tests/unit/orders.rs
@@ -1,7 +1,7 @@
 use bigneon_db::dev::times;
 use bigneon_db::dev::TestProject;
 use bigneon_db::models::*;
-use bigneon_db::schema::{order_items, orders, ticket_instances};
+use bigneon_db::schema::{fee_schedule_ranges, order_items, orders, ticket_instances};
 use bigneon_db::utils::errors::DatabaseError;
 use bigneon_db::utils::errors::ErrorCode::ValidationError;
 use chrono::prelude::*;
@@ -2412,10 +2412,10 @@ fn add_tickets_below_min_fee() {
             connection,
         )
         .unwrap();
-
     let user = project.create_user().finish();
-    let mut cart = Order::find_or_create_cart(&user, connection).unwrap();
 
+    // With a minimum fee schedule of 0
+    let mut cart = Order::find_or_create_cart(&user, connection).unwrap();
     cart.update_quantities(
         user.id,
         &vec![UpdateOrderItem {
@@ -2428,14 +2428,40 @@ fn add_tickets_below_min_fee() {
         connection,
     )
     .unwrap();
+    let items = cart.items(&connection).unwrap();
+    let order_item = items.iter().find(|i| i.ticket_type_id == Some(ticket_type.id)).unwrap();
+    assert_eq!(order_item.unit_price_in_cents, 0);
+    assert_eq!(items.len(), 2);
 
+    let fee_item = order_item.find_fee_item(connection).unwrap().unwrap();
+    assert_eq!(fee_item.unit_price_in_cents, 0);
+    assert_eq!(fee_item.client_fee_in_cents, 0);
+    assert_eq!(fee_item.company_fee_in_cents, 0);
+
+    // Without the minimum fee schedule of 0
+    cart.clear_cart(user.id, connection);
+    diesel::delete(fee_schedule_ranges::table.filter(fee_schedule_ranges::min_price_in_cents.eq(0)))
+        .execute(connection)
+        .unwrap();
+    cart.update_quantities(
+        user.id,
+        &vec![UpdateOrderItem {
+            ticket_type_id: ticket_type.id,
+            quantity: 10,
+            redemption_code: None,
+        }],
+        false,
+        false,
+        connection,
+    )
+    .unwrap();
     let items = cart.items(&connection).unwrap();
     let order_item = items.iter().find(|i| i.ticket_type_id == Some(ticket_type.id)).unwrap();
     assert_eq!(order_item.unit_price_in_cents, 0);
     assert_eq!(items.len(), 1);
 
     let fee_item = order_item.find_fee_item(connection).unwrap();
-    assert_eq!(fee_item, None);
+    assert!(fee_item.is_none());
 }
 
 #[test]

--- a/db/tests/unit/orders.rs
+++ b/db/tests/unit/orders.rs
@@ -2439,7 +2439,7 @@ fn add_tickets_below_min_fee() {
     assert_eq!(fee_item.company_fee_in_cents, 0);
 
     // Without the minimum fee schedule of 0
-    cart.clear_cart(user.id, connection);
+    cart.clear_cart(user.id, connection).unwrap();
     diesel::delete(fee_schedule_ranges::table.filter(fee_schedule_ranges::min_price_in_cents.eq(0)))
         .execute(connection)
         .unwrap();

--- a/db/tests/unit/settlements.rs
+++ b/db/tests/unit/settlements.rs
@@ -353,6 +353,88 @@ fn create_post_event_entries() {
 }
 
 #[test]
+fn settlement_free_ticket_with_ticket_fee_behavior() {
+    let project = TestProject::new();
+    let connection = project.get_connection();
+    let user = project.create_user().finish();
+    let organization = project
+        .create_organization()
+        .with_fees()
+        .with_max_additional_fee(1000)
+        .finish();
+    let ticket_type = project
+        .create_event()
+        .with_organization(&organization)
+        .with_ticket_type()
+        .with_price(10)
+        .with_additional_fees(1000)
+        .finish()
+        .ticket_types(false, None, connection)
+        .unwrap()
+        .remove(0);
+    let hold = project
+        .create_hold()
+        .with_hold_type(HoldTypes::Discount)
+        .with_quantity(10)
+        .with_discount_in_cents(10)
+        .with_ticket_type_id(ticket_type.id)
+        .finish();
+    let event = Event::find(ticket_type.event_id, connection).unwrap();
+    let mut order = project
+        .create_order()
+        .for_event(&event)
+        .with_redemption_code(hold.redemption_code.clone().unwrap())
+        .is_paid()
+        .finish();
+    let items = order.items(&connection).unwrap();
+    let order_item = items.iter().find(|i| i.ticket_type_id == Some(ticket_type.id)).unwrap();
+    let tickets = TicketInstance::find_for_order_item(order_item.id, connection).unwrap();
+    let ticket = &tickets[0];
+    let refund_items = vec![RefundItemRequest {
+        order_item_id: order_item.id,
+        ticket_instance_id: Some(ticket.id),
+    }];
+    // refund one ticket bringing total of fees down to 9
+    order.refund(&refund_items, user.id, None, connection).unwrap();
+
+    let settlement = Settlement::create(
+        organization.id,
+        dates::now().add_days(-5).finish(),
+        dates::now().add_days(2).finish(),
+        SettlementStatus::PendingSettlement,
+        None,
+        false,
+    )
+    .commit(None, connection)
+    .unwrap();
+
+    let display_settlement = settlement.clone().for_display(connection).unwrap();
+    assert_eq!(display_settlement.event_entries.len(), 1);
+    let event_entries_data = &display_settlement.event_entries[0];
+    let event_entries = &event_entries_data.entries;
+    assert_eq!(event_entries.len(), 1);
+
+    let ticket_type_entry = event_entries
+        .clone()
+        .into_iter()
+        .find(|e| {
+            e.settlement_entry_type == SettlementEntryTypes::TicketType && e.ticket_type_id == Some(ticket_type.id)
+        })
+        .unwrap();
+    assert_eq!(ticket_type_entry.settlement_id, settlement.id);
+    assert_eq!(ticket_type_entry.event_id, event.id);
+    assert_eq!(ticket_type_entry.ticket_type_id, Some(ticket_type.id));
+    assert_eq!(ticket_type_entry.face_value_in_cents, 0);
+    assert_eq!(ticket_type_entry.revenue_share_value_in_cents, 1000);
+    assert_eq!(ticket_type_entry.online_sold_quantity, 9);
+    assert_eq!(ticket_type_entry.fee_sold_quantity, 9);
+    assert_eq!(
+        ticket_type_entry.total_sales_in_cents,
+        ticket_type_entry.fee_sold_quantity * ticket_type_entry.revenue_share_value_in_cents
+    );
+}
+
+#[test]
 // Note this logic is only needed for a transitional period of time
 // Currently in production we're manually peforming settlement reports so order exist that have been
 // included in a settlement but not marked as such. The logic acts as though the orders prior to the


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1149047845558135/1150334593926825

### Description:
An issue was noticed from some live testing where free tickets with fees weren't getting included. This PR adjusts the settlement function to include those items.

Before fix:
![Screen Shot 2019-11-20 at 4 27 47 PM](https://user-images.githubusercontent.com/1319304/69280729-ffb08a00-0bb4-11ea-9e62-f8a01b8fac60.png)

After fix:
![Screen Shot 2019-11-20 at 4 51 55 PM](https://user-images.githubusercontent.com/1319304/69281341-1c998d00-0bb6-11ea-89eb-606e7b63f85e.png)

Note:
- When testing if an organization does not have a fee schedule range of min price 0 then these fees are not presented / it's 100% free. Our automated tests create organizations without a min price 0 fee schedule range but the frontend does create it.

## Release Details:
Once this has gone live I will provide two SQL statements to update the associated organization's settlements by having it rerun the event in question with this state (it'll only add ones missing from the initial run).

### Migrations
 * No Migrations

### Environment Variables
 * No change
