### PR TITLE
Adjust logic for city slug creation

### DIFF
--- a/db/tests/unit/slugs.rs
+++ b/db/tests/unit/slugs.rs
@@ -141,13 +141,12 @@ fn find_first_for_city() {
     let project = TestProject::new();
     let connection = project.get_connection();
 
+    // US city
     let city = "Oakland".to_string();
     let state = "California".to_string();
     let country = "US".to_string();
-
     // No records exist for this slug
     assert!(Slug::find_first_for_city(&city, &state, &country, connection).is_err());
-
     let venue = project
         .create_venue()
         .with_city(city.clone())
@@ -158,6 +157,25 @@ fn find_first_for_city() {
     assert_eq!(slug.main_table_id, venue.id);
     assert_eq!(slug.main_table, Tables::Venues);
     assert_eq!(slug.slug_type, SlugTypes::City);
+    assert_eq!(slug.slug, "oakland".to_string());
+
+    // Country without states
+    let city = "Cape Town".to_string();
+    let state = "".to_string();
+    let country = "SA".to_string();
+    // No records exist for this slug
+    assert!(Slug::find_first_for_city(&city, &state, &country, connection).is_err());
+    let venue = project
+        .create_venue()
+        .with_city(city.clone())
+        .with_state(state.clone())
+        .with_country(country.clone())
+        .finish();
+    let slug = Slug::find_first_for_city(&city, &state, &country, connection).unwrap();
+    assert_eq!(slug.main_table_id, venue.id);
+    assert_eq!(slug.main_table, Tables::Venues);
+    assert_eq!(slug.slug_type, SlugTypes::City);
+    assert_eq!(slug.slug, "cape-town".to_string());
 }
 
 #[test]


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1149047845558135/1150659194555993

### Description:
Issue relates to city slugs not being generated without a country so the display venues is failing as the logic appears to expect one.

Changes:
- Display venue no longer requires city slug
- The logic to generate a city slug no longer requires a country or state

Note:
- Testing this is a bit of a pain because the frontend prevents venues from being created without a city, state, and country. To test this I used curl to create these sorts of venues / future proofs it when states aren't required.

## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
