### PR TITLE
Add eventref to ticket url

### DIFF
--- a/api/src/controllers/external/facebook.rs
+++ b/api/src/controllers/external/facebook.rs
@@ -290,7 +290,11 @@ pub fn create_event(
         EventLocationType::CustomAddress => fb_event.address = data.custom_address.clone(),
     }
 
-    fb_event.ticket_uri = Some(format!("{}/tickets/{}", state.config.front_end_url, event.slug(conn)?));
+    fb_event.ticket_uri = Some(format!(
+        "{}/tickets/{}?eventref=fb_oea",
+        state.config.front_end_url,
+        event.slug(conn)?
+    ));
 
     fb_event.admins.push(data.page_id.clone());
 


### PR DESCRIPTION
### References Issues:

### Description:
Add eventref to tickets url from Facebook events. FB documentation says it should be added automatically, but doesn't seem to be the case 

## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
