### PR TITLE
Fix the superuser creation by using updated User result

### DIFF
--- a/db/src/bin.rs
+++ b/db/src/bin.rs
@@ -251,7 +251,8 @@ fn create_db_and_user(matches: &ArgMatches) {
     )
     .commit(None, &db_connection)
     .expect("Failed to create system admin");
-    user.add_role(Roles::Admin, &db_connection)
+    let user = user
+        .add_role(Roles::Admin, &db_connection)
         .expect("Could not assign System Administrator role to the user");
     user.add_role(Roles::Super, &db_connection)
         .expect("Could not assign System Administrator role to the user");


### PR DESCRIPTION
### Description:
Fixes the problem when creating the superuser account. Only `Super` was being added to the roles array, now both are being added.
## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
