### PR TITLE
Add parent name to ticket types response

### DIFF
--- a/api/src/models/admin_display_ticket_type.rs
+++ b/api/src/models/admin_display_ticket_type.rs
@@ -22,6 +22,7 @@ pub struct AdminDisplayTicketType {
     pub price_in_cents: i64,
     pub visibility: TicketTypeVisibility,
     pub parent_id: Option<Uuid>,
+    pub parent_name: Option<String>,
     pub additional_fee_in_cents: i64,
     pub rank: i32,
     pub app_sales_enabled: bool,
@@ -50,6 +51,11 @@ impl AdminDisplayTicketType {
             )?);
         }
 
+        let parent_name = match ticket_type.parent_id {
+            Some(parent_id) => Some(TicketType::find(parent_id, conn)?.name),
+            None => None,
+        };
+
         let mut result = AdminDisplayTicketType {
             id: ticket_type.id,
             name: ticket_type.name.clone(),
@@ -59,6 +65,7 @@ impl AdminDisplayTicketType {
                 .start_date
                 .and_then(|sd| if sd <= times::zero() { None } else { Some(sd) }),
             parent_id: ticket_type.parent_id,
+            parent_name,
             end_date: ticket_type.end_date,
             end_date_type: ticket_type.end_date_type,
             ticket_pricing: ticket_pricing_list.clone(),


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1151234524692625/1110258272725761

### Description:
It was mentioned in the associated asana issue that there was some issue getting the start date for some ticket types. Child ticket types have null start dates so that issue was unrelated to any API bugs. It was noticed that the new view UI would need to call for the parents of each ticket type in order to display their names. This patch simply does that query prior to returning the response so they can just render the parent's name more easily.

![Screen Shot 2020-01-10 at 3 32 42 PM](https://user-images.githubusercontent.com/1319304/72185375-a6005b00-33c0-11ea-8a7b-faeb1f6aec37.png)


## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
