### PR TITLE
Update event broadcasts as well as their related domain action

### DIFF
--- a/api/src/routing.rs
+++ b/api/src/routing.rs
@@ -119,6 +119,7 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
     .resource("/events/{id}/broadcasts", |r| {
         r.method(Method::POST).with(broadcasts::create);
         r.method(Method::GET).with(broadcasts::index);
+        r.method(Method::PUT).with(broadcasts::update);
     })
     .resource("/events/{id}/links", |r| {
         r.method(Method::POST).with(events::create_link);

--- a/db/src/models/broadcasts.rs
+++ b/db/src/models/broadcasts.rs
@@ -174,15 +174,42 @@ impl Broadcast {
                 ErrorCode::UpdateError,
                 Some("This broadcast has been cancelled, it cannot be modified.".to_string()),
             )),
+            BroadcastStatus::InProgress => Err(DatabaseError::new(
+                ErrorCode::UpdateError,
+                Some("This broadcast is in progress, it cannot be modified.".to_string()),
+            )),
+            BroadcastStatus::Completed => Err(DatabaseError::new(
+                ErrorCode::UpdateError,
+                Some("This broadcast has completed, it cannot be modified.".to_string()),
+            )),
             _ => {
                 self.validate_record(&attributes, connection)?;
-                DatabaseError::wrap(
+                let domain_actions = DomainAction::find_by_resource(
+                    Some(Tables::Broadcasts),
+                    Some(self.id),
+                    DomainActionTypes::BroadcastPushNotification,
+                    DomainActionStatus::Pending,
+                    connection,
+                )?;
+
+                let send_at = attributes.send_at.clone();
+                let result = DatabaseError::wrap(
                     ErrorCode::UpdateError,
                     "Could not update broadcast",
                     diesel::update(self)
                         .set((attributes, broadcasts::updated_at.eq(dsl::now)))
                         .get_result(connection),
-                )
+                );
+
+                if let Some(send_at) = send_at {
+                    if let Some(send_at) = send_at {
+                        for domain_action in domain_actions {
+                            domain_action.set_scheduled_at(send_at.clone(), connection)?;
+                        }
+                    }
+                }
+
+                result
             }
         }
     }
@@ -213,6 +240,17 @@ impl Broadcast {
                 conn,
             )?,
         );
+
+        //Check that we are not updating a broadcast that has already been run
+        let validation_errors = validators::append_validation_error(
+            validation_errors,
+            "send_at",
+            Broadcast::send_at_has_not_passed(
+                self.send_at,
+                attributes.send_at.clone().unwrap_or(self.send_at.clone()),
+                conn,
+            )?,
+        );
         Ok(validation_errors?)
     }
 
@@ -232,6 +270,33 @@ impl Broadcast {
                 let validation_error =
                     create_validation_error("custom_message_empty", "Custom messages cannot be blank");
                 return Ok(Err(validation_error));
+            }
+        }
+    }
+
+    fn send_at_has_not_passed(
+        send_at: Option<NaiveDateTime>,
+        new_send_at: Option<NaiveDateTime>,
+        _connection: &PgConnection,
+    ) -> Result<Result<(), ValidationError>, DatabaseError> {
+        match send_at {
+            Some(_send_at) => {
+                if let Some(new_send_at) = new_send_at {
+                    if new_send_at <= Utc::now().naive_utc() {
+                        return Ok(Err(create_validation_error(
+                            "send_at_in_the_past",
+                            "The send_at field should be set to a time in the future",
+                        )));
+                    }
+                }
+                return Ok(Ok(()));
+            }
+            None => {
+                // If the send_at is None then it was sent immediately, so you cannot update it.
+                return Ok(Err(create_validation_error(
+                    "broadcast_already_sent",
+                    "This broadcast has already been sent, you cannot update the send_at time",
+                )));
             }
         }
     }

--- a/db/src/utils/dates.rs
+++ b/db/src/utils/dates.rs
@@ -1,6 +1,7 @@
 use chrono::prelude::*;
 use chrono::Duration;
 
+#[derive(Clone)]
 pub struct DateBuilder {
     date: NaiveDateTime,
 }

--- a/db/tests/unit/broadcasts.rs
+++ b/db/tests/unit/broadcasts.rs
@@ -142,6 +142,47 @@ fn broadcast_update() {
 }
 
 #[test]
+fn broadcast_update_send_at() {
+    let project = TestProject::new();
+    let conn = project.get_connection();
+
+    let broadcast = project
+        .create_broadcast()
+        .with_channel(BroadcastChannel::PushNotification)
+        .with_send_at(Utc::now().naive_utc())
+        .with_status(BroadcastStatus::Pending)
+        .finish();
+
+    let new_send_at = Some(dates::now().add_seconds(60).finish());
+
+    let attributes = BroadcastEditableAttributes {
+        notification_type: None,
+        channel: None,
+        name: None,
+        message: None,
+        send_at: Some(new_send_at.clone()),
+        status: None,
+    };
+
+    let broadcast = broadcast.update(attributes, conn).unwrap();
+
+    assert_eq!(broadcast.status, BroadcastStatus::Pending);
+    assert_eq!(broadcast.channel, BroadcastChannel::PushNotification);
+    assert_eq!(broadcast.send_at, new_send_at.clone());
+
+    let domain_actions = DomainAction::find_by_resource(
+        Some(Tables::Broadcasts),
+        Some(broadcast.id),
+        DomainActionTypes::BroadcastPushNotification,
+        DomainActionStatus::Pending,
+        conn,
+    )
+    .unwrap();
+
+    assert_eq!(domain_actions.get(0).scheduled_at, new_send_at.unwrap());
+}
+
+#[test]
 fn broadcast_update_if_cancelled() {
     let project = TestProject::new();
     let conn = project.get_connection();

--- a/db/tests/unit/broadcasts.rs
+++ b/db/tests/unit/broadcasts.rs
@@ -179,7 +179,7 @@ fn broadcast_update_send_at() {
     )
     .unwrap();
 
-    assert_eq!(domain_actions.get(0).scheduled_at, new_send_at.unwrap());
+    assert_eq!(domain_actions[0].scheduled_at, new_send_at.unwrap());
 }
 
 #[test]


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1153926226800754/1155691976771297/f
https://app.asana.com/0/1156907105711882/1157220402023137
### Description:
As well as adding the route to update, we needed to update the pending domain actions to reschedule them if it is allowed.
## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
