### PR TITLE
Additional endpoint caching, switch to middleware approach

### DIFF
--- a/api/src/controllers/events.rs
+++ b/api/src/controllers/events.rs
@@ -230,45 +230,6 @@ pub fn checkins(
     Ok(HttpResponse::Ok().json(&payload))
 }
 
-pub fn index_cached(
-    (state, connection, query, auth_user, cache_database): (
-        State<AppState>,
-        ReadonlyConnection,
-        Query<SearchParameters>,
-        OptionalUser,
-        CacheDatabase,
-    ),
-) -> Result<HttpResponse, BigNeonError> {
-    let search_params = query.clone();
-    let user = auth_user
-        .clone()
-        .into_inner()
-        .and_then(|auth_user| Some(auth_user.user));
-
-    let config = state.config.clone();
-    if user.is_none() {
-        // if there is a error in the cache, the value does not exist
-        let cached_value = cache_database
-            .clone()
-            .inner
-            .clone()
-            .and_then(|conn| caching::get_cached_value(conn, &config, &search_params));
-        if let Some(response) = cached_value {
-            return Ok(response);
-        }
-    }
-    let index_value = index((state, connection, query, auth_user))?;
-
-    if user.is_none() {
-        cache_database
-            .inner
-            .clone()
-            .and_then(|conn| caching::set_cached_value(conn, &config, &index_value, &search_params).ok());
-    }
-
-    return Ok(index_value);
-}
-
 pub fn index(
     (state, connection, query, auth_user): (
         State<AppState>,

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -10,6 +10,7 @@ extern crate actix;
 extern crate actix_web;
 #[macro_use]
 extern crate bigneon_db;
+extern crate bigneon_http;
 extern crate branch_rs;
 extern crate chrono;
 extern crate customer_io;

--- a/api/src/middleware/cache_resource.rs
+++ b/api/src/middleware/cache_resource.rs
@@ -1,15 +1,17 @@
-use actix_web::http::header::{HeaderName, HeaderValue};
-use actix_web::http::{HttpTryFrom, Method};
+use actix_web::http::header::*;
+use actix_web::http::{HttpTryFrom, Method, StatusCode};
 use actix_web::middleware::{Middleware, Response, Started};
-use actix_web::{FromRequest, HttpRequest, HttpResponse, Result};
+use actix_web::{Body, FromRequest, HttpRequest, HttpResponse, Result};
+use bigneon_http::caching::*;
 use extractors::*;
 use helpers::*;
+use serde_json::Value;
 use server::AppState;
 use std::collections::BTreeMap;
+use uuid::Uuid;
 
 const CACHED_RESPONSE_HEADER: &'static str = "X-Cached-Response";
 
-#[derive(Clone)]
 pub struct CacheResource {}
 
 impl CacheResource {
@@ -18,8 +20,27 @@ impl CacheResource {
     }
 }
 
+pub struct CacheConfiguration {
+    cache_response: bool,
+    served_cache: bool,
+    error: bool,
+    user_id: Option<Uuid>,
+}
+
+impl CacheConfiguration {
+    pub fn new() -> CacheConfiguration {
+        CacheConfiguration {
+            cache_response: false,
+            served_cache: false,
+            error: false,
+            user_id: None,
+        }
+    }
+}
+
 impl Middleware<AppState> for CacheResource {
     fn start(&self, request: &HttpRequest<AppState>) -> Result<Started> {
+        let mut cache_configuration = CacheConfiguration::new();
         if request.method() == Method::GET {
             let mut query = BTreeMap::new();
             let resource = request.resource().clone();
@@ -31,68 +52,133 @@ impl Middleware<AppState> for CacheResource {
             if resource_def.is_none() {
                 return Ok(Started::Done);
             }
-            let path_text = "path".to_string();
             let path = resource_def.unwrap().pattern().to_string();
-            let method_text = "method".to_string();
+            let path_text = "path".to_string();
             let method = request.method().to_string();
+            let method_text = "method".to_string();
+            let user_text = "x-user-id".to_string();
             query.insert(&path_text, &path);
             query.insert(&method_text, &method);
             let state = request.state().clone();
             let config = state.config.clone();
-            let user = OptionalUser::from_request(request, &());
-            if user.is_ok() && user.unwrap().0.is_none() {
-                let cache_database = state.database.cache_database.clone();
-                // if there is a error in the cache, the value does not exist
-                let cached_value = cache_database
-                    .clone()
-                    .inner
-                    .clone()
-                    .and_then(|conn| caching::get_cached_value(conn, &config, &query));
-                if let Some(response) = cached_value {
-                    // Insert self into extensions to let response know not to set the value
-                    request.extensions_mut().insert(self.clone());
-                    return Ok(Started::Response(response));
+            let mut user_value = "".to_string();
+            match OptionalUser::from_request(request, &()) {
+                Ok(user) => {
+                    cache_configuration.user_id = user.0.map(|u| u.id());
+                    if let Some(user_id) = cache_configuration.user_id {
+                        user_value = user_id.to_string();
+                    }
+                    query.insert(&user_text, &user_value);
                 }
+                Err(error) => {
+                    cache_configuration.error = true;
+                    error!("CacheResource Middleware start: {:?}", error);
+                    request.extensions_mut().insert(cache_configuration);
+                    return Ok(Started::Done);
+                }
+            }
+
+            let cache_database = state.database.cache_database.clone();
+            // if there is a error in the cache, the value does not exist
+            let cached_value = cache_database
+                .clone()
+                .inner
+                .clone()
+                .and_then(|conn| caching::get_cached_value(conn, &config, &query));
+            if let Some(response) = cached_value {
+                // Insert self into extensions to let response know not to set the value
+                cache_configuration.served_cache = true;
+                request.extensions_mut().insert(cache_configuration);
+                return Ok(Started::Response(response));
             }
         }
 
+        cache_configuration.cache_response = true;
+        request.extensions_mut().insert(cache_configuration);
         Ok(Started::Done)
     }
 
     fn response(&self, request: &HttpRequest<AppState>, mut response: HttpResponse) -> Result<Response> {
         if request.method() == Method::GET {
-            let mut query = BTreeMap::new();
-            let resource = request.resource().clone();
-            let query_parameters = request.query();
-            for (key, value) in query_parameters.iter() {
-                query.insert(key, value);
-            }
-            let resource_def = resource.rdef().clone();
-            if resource_def.is_none() {
-                return Ok(Response::Done(response));
-            }
-            let path_text = "path".to_string();
-            let path = resource_def.unwrap().pattern().to_string();
-            let method_text = "method".to_string();
-            let method = request.method().to_string();
-            query.insert(&path_text, &path);
-            query.insert(&method_text, &method);
-            let state = request.state().clone();
-            let config = state.config.clone();
             let extensions = request.extensions();
-            let cached = extensions.get::<CacheResource>();
-            let user = OptionalUser::from_request(request, &());
-            if cached.is_none() && user.is_ok() && user.unwrap().0.is_none() {
-                let cache_database = state.database.cache_database.clone();
-                cache_database
-                    .inner
-                    .clone()
-                    .and_then(|conn| caching::set_cached_value(conn, &config, &response, &query).ok());
-            } else if cached.is_some() {
-                response.headers_mut().insert(
-                    &HeaderName::try_from(CACHED_RESPONSE_HEADER).unwrap(),
-                    HeaderValue::from_static("1"),
-                );
+            if let Some(cache_configuration) = extensions.get::<CacheConfiguration>() {
+                let state = request.state().clone();
+                let config = state.config.clone();
+
+                if cache_configuration.cache_response {
+                    let cache_database = state.database.cache_database.clone();
+                    let mut query = BTreeMap::new();
+                    let resource = request.resource().clone();
+                    let query_parameters = request.query();
+                    for (key, value) in query_parameters.iter() {
+                        query.insert(key, value);
+                    }
+                    let resource_def = resource.rdef().clone();
+                    if resource_def.is_none() {
+                        return Ok(Response::Done(response));
+                    }
+                    let path = resource_def.unwrap().pattern().to_string();
+                    let path_text = "path".to_string();
+                    let method = request.method().to_string();
+                    let method_text = "method".to_string();
+                    let user_text = "x-user-id".to_string();
+                    let user_id = cache_configuration
+                        .user_id
+                        .map(|u| u.to_string())
+                        .unwrap_or("".to_string());
+                    query.insert(&path_text, &path);
+                    query.insert(&method_text, &method);
+                    query.insert(&user_text, &user_id);
+
+                    cache_database
+                        .inner
+                        .clone()
+                        .and_then(|conn| caching::set_cached_value(conn, &config, &response, &query).ok());
+                }
+
+                if cache_configuration.served_cache {
+                    response.headers_mut().insert(
+                        &HeaderName::try_from(CACHED_RESPONSE_HEADER).unwrap(),
+                        HeaderValue::from_static("1"),
+                    );
+                }
+
+                // If an error occurred fetching db data, do not send caching headers
+                if !cache_configuration.error {
+                    // Cache headers for client
+                    if let Ok(cache_control_header_value) = HeaderValue::from_str(&format!(
+                        "{}, max-age={}",
+                        if cache_configuration.user_id.is_none() {
+                            "public"
+                        } else {
+                            "private"
+                        },
+                        config.client_cache_period
+                    )) {
+                        response
+                            .headers_mut()
+                            .insert(&CACHE_CONTROL, cache_control_header_value);
+                    }
+
+                    if let Ok(response_str) = application::unwrap_body_to_string(&response) {
+                        if let Ok(payload) = serde_json::from_str::<Value>(&response_str) {
+                            let etag_hash = etag_hash(&payload.to_string());
+                            if let Ok(new_header_value) = HeaderValue::from_str(&etag_hash) {
+                                response.headers_mut().insert(&ETAG, new_header_value);
+                                if request.headers().contains_key(IF_NONE_MATCH) {
+                                    let etag = ETag(EntityTag::weak(etag_hash.to_string()));
+                                    if let Ok(header_value) = request.headers()[IF_NONE_MATCH].to_str() {
+                                        let etag_header = ETag(EntityTag::weak(header_value.to_string()));
+                                        if etag.weak_eq(&etag_header) {
+                                            response.set_body(Body::Empty);
+                                            *response.status_mut() = StatusCode::NOT_MODIFIED;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/api/src/middleware/cache_resource.rs
+++ b/api/src/middleware/cache_resource.rs
@@ -1,0 +1,92 @@
+use actix_web::middleware::{Middleware, Response, Started};
+use actix_web::{http::Method, FromRequest, HttpRequest, HttpResponse, Result};
+use extractors::*;
+use helpers::*;
+use server::AppState;
+use std::collections::BTreeMap;
+
+#[derive(Clone)]
+pub struct CacheResource {}
+
+impl CacheResource {
+    pub fn new() -> CacheResource {
+        CacheResource {}
+    }
+}
+
+impl Middleware<AppState> for CacheResource {
+    fn start(&self, request: &HttpRequest<AppState>) -> Result<Started> {
+        if request.method() == Method::GET {
+            let mut query = BTreeMap::new();
+            let resource = request.resource().clone();
+            let query_parameters = request.query().clone();
+            for (key, value) in query_parameters.iter() {
+                query.insert(key, value);
+            }
+            let resource_def = resource.rdef().clone();
+            if resource_def.is_none() {
+                return Ok(Started::Done);
+            }
+            let path_text = "path".to_string();
+            let path = resource_def.unwrap().pattern().to_string();
+            let method_text = "method".to_string();
+            let method = request.method().to_string();
+            query.insert(&path_text, &path);
+            query.insert(&method_text, &method);
+            let state = request.state().clone();
+            let config = state.config.clone();
+            let user = OptionalUser::from_request(request, &());
+            if user.is_ok() && user.unwrap().0.is_none() {
+                let cache_database = state.database.cache_database.clone();
+                // if there is a error in the cache, the value does not exist
+                let cached_value = cache_database
+                    .clone()
+                    .inner
+                    .clone()
+                    .and_then(|conn| caching::get_cached_value(conn, &config, &query));
+                if let Some(response) = cached_value {
+                    // Insert self into extensions to let response know not to set the value
+                    request.extensions_mut().insert(self.clone());
+                    return Ok(Started::Response(response));
+                }
+            }
+        }
+
+        Ok(Started::Done)
+    }
+
+    fn response(&self, request: &HttpRequest<AppState>, response: HttpResponse) -> Result<Response> {
+        if request.method() == Method::GET {
+            let mut query = BTreeMap::new();
+            let resource = request.resource().clone();
+            let query_parameters = request.query();
+            for (key, value) in query_parameters.iter() {
+                query.insert(key, value);
+            }
+            let resource_def = resource.rdef().clone();
+            if resource_def.is_none() {
+                return Ok(Response::Done(response));
+            }
+            let path_text = "path".to_string();
+            let path = resource_def.unwrap().pattern().to_string();
+            let method_text = "method".to_string();
+            let method = request.method().to_string();
+            query.insert(&path_text, &path);
+            query.insert(&method_text, &method);
+            let state = request.state().clone();
+            let config = state.config.clone();
+            let extensions = request.extensions();
+            let cached = extensions.get::<CacheResource>();
+            let user = OptionalUser::from_request(request, &());
+            if cached.is_none() && user.is_ok() && user.unwrap().0.is_none() {
+                let cache_database = state.database.cache_database.clone();
+                cache_database
+                    .inner
+                    .clone()
+                    .and_then(|conn| caching::set_cached_value(conn, &config, &response, &query).ok());
+            }
+        }
+
+        Ok(Response::Done(response))
+    }
+}

--- a/api/src/middleware/mod.rs
+++ b/api/src/middleware/mod.rs
@@ -1,9 +1,11 @@
 pub use self::app_version_header::*;
 pub use self::big_neon_logger::*;
+pub use self::cache_resource::*;
 pub use self::database_transaction::*;
 pub use self::metatags::*;
 
 mod app_version_header;
 mod big_neon_logger;
+mod cache_resource;
 mod database_transaction;
 mod metatags;

--- a/api/src/routing.rs
+++ b/api/src/routing.rs
@@ -1,6 +1,7 @@
 use actix_web::middleware::cors::CorsBuilder;
 use actix_web::{http::Method, App, HttpResponse};
 use controllers::*;
+use middleware::CacheResource;
 use server::AppState;
 
 pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
@@ -19,16 +20,19 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
         r.method(Method::GET).with(analytics::track);
     })
     .resource("/artists/search", |r| {
+        r.middleware(CacheResource::new());
         r.method(Method::GET).with(artists::search);
     })
     .resource("/artists/{id}/toggle_privacy", |r| {
         r.method(Method::PUT).with(artists::toggle_privacy);
     })
     .resource("/artists/{id}", |r| {
+        r.middleware(CacheResource::new());
         r.method(Method::GET).with(artists::show);
         r.method(Method::PUT).with(artists::update);
     })
     .resource("/artists", |r| {
+        r.middleware(CacheResource::new());
         r.method(Method::GET).with(artists::index);
         r.method(Method::POST).with(artists::create);
     })
@@ -76,13 +80,15 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
         r.method(Method::DELETE).with(event_report_subscribers::destroy);
     })
     .resource("/events", |r| {
-        r.method(Method::GET).with(events::index_cached);
+        r.middleware(CacheResource::new());
+        r.method(Method::GET).with(events::index);
         r.method(Method::POST).with(events::create);
     })
     .resource("/events/checkins", |r| {
         r.method(Method::GET).with(events::checkins);
     })
     .resource("/events/{id}", |r| {
+        r.middleware(CacheResource::new());
         r.method(Method::GET).with(events::show);
         r.method(Method::PUT).with(events::update);
         r.method(Method::DELETE).with(events::cancel);
@@ -185,6 +191,7 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
         r.method(Method::DELETE).with(external::facebook::disconnect);
     })
     .resource("/genres", |r| {
+        r.middleware(CacheResource::new());
         r.method(Method::GET).with(genres::index);
     })
     .resource("/invitations/{id}", |r| {
@@ -326,10 +333,12 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
         r.method(Method::GET).with(redemption_codes::show)
     })
     .resource("/regions/{id}", |r| {
+        r.middleware(CacheResource::new());
         r.method(Method::GET).with(regions::show);
         r.method(Method::PUT).with(regions::update);
     })
     .resource("/regions", |r| {
+        r.middleware(CacheResource::new());
         r.method(Method::GET).with(regions::index);
         r.method(Method::POST).with(regions::create)
     })
@@ -432,14 +441,17 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
         r.method(Method::PUT).with(venues::toggle_privacy);
     })
     .resource("/venues/{id}", |r| {
+        r.middleware(CacheResource::new());
         r.method(Method::GET).with(venues::show);
         r.method(Method::PUT).with(venues::update);
     })
     .resource("/venues", |r| {
+        r.middleware(CacheResource::new());
         r.method(Method::GET).with(venues::index);
         r.method(Method::POST).with(venues::create);
     })
     .resource("/sitemap.xml", |r| {
+        r.middleware(CacheResource::new());
         r.method(Method::GET).with(sitemap_gen::index);
     })
     .register()

--- a/api/src/routing.rs
+++ b/api/src/routing.rs
@@ -1,7 +1,7 @@
 use actix_web::middleware::cors::CorsBuilder;
 use actix_web::{http::Method, App, HttpResponse};
 use controllers::*;
-use middleware::CacheResource;
+use middleware::{CacheResource, CacheUsersBy};
 use server::AppState;
 
 pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
@@ -20,19 +20,19 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
         r.method(Method::GET).with(analytics::track);
     })
     .resource("/artists/search", |r| {
-        r.middleware(CacheResource::new());
+        r.middleware(CacheResource::new(CacheUsersBy::AnonymousOnly));
         r.method(Method::GET).with(artists::search);
     })
     .resource("/artists/{id}/toggle_privacy", |r| {
         r.method(Method::PUT).with(artists::toggle_privacy);
     })
     .resource("/artists/{id}", |r| {
-        r.middleware(CacheResource::new());
+        r.middleware(CacheResource::new(CacheUsersBy::None));
         r.method(Method::GET).with(artists::show);
         r.method(Method::PUT).with(artists::update);
     })
     .resource("/artists", |r| {
-        r.middleware(CacheResource::new());
+        r.middleware(CacheResource::new(CacheUsersBy::AnonymousOnly));
         r.method(Method::GET).with(artists::index);
         r.method(Method::POST).with(artists::create);
     })
@@ -80,7 +80,8 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
         r.method(Method::DELETE).with(event_report_subscribers::destroy);
     })
     .resource("/events", |r| {
-        r.middleware(CacheResource::new());
+        // In future it may be better to cache this for every user to save the database hit
+        r.middleware(CacheResource::new(CacheUsersBy::GlobalRoles));
         r.method(Method::GET).with(events::index);
         r.method(Method::POST).with(events::create);
     })
@@ -88,7 +89,8 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
         r.method(Method::GET).with(events::checkins);
     })
     .resource("/events/{id}", |r| {
-        r.middleware(CacheResource::new());
+        // In future it may be better to cache this for every user to save the database hit
+        r.middleware(CacheResource::new(CacheUsersBy::GlobalRoles));
         r.method(Method::GET).with(events::show);
         r.method(Method::PUT).with(events::update);
         r.method(Method::DELETE).with(events::cancel);
@@ -191,7 +193,7 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
         r.method(Method::DELETE).with(external::facebook::disconnect);
     })
     .resource("/genres", |r| {
-        r.middleware(CacheResource::new());
+        r.middleware(CacheResource::new(CacheUsersBy::None));
         r.method(Method::GET).with(genres::index);
     })
     .resource("/invitations/{id}", |r| {
@@ -333,12 +335,12 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
         r.method(Method::GET).with(redemption_codes::show)
     })
     .resource("/regions/{id}", |r| {
-        r.middleware(CacheResource::new());
+        r.middleware(CacheResource::new(CacheUsersBy::None));
         r.method(Method::GET).with(regions::show);
         r.method(Method::PUT).with(regions::update);
     })
     .resource("/regions", |r| {
-        r.middleware(CacheResource::new());
+        r.middleware(CacheResource::new(CacheUsersBy::None));
         r.method(Method::GET).with(regions::index);
         r.method(Method::POST).with(regions::create)
     })
@@ -441,17 +443,17 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
         r.method(Method::PUT).with(venues::toggle_privacy);
     })
     .resource("/venues/{id}", |r| {
-        r.middleware(CacheResource::new());
+        r.middleware(CacheResource::new(CacheUsersBy::None));
         r.method(Method::GET).with(venues::show);
         r.method(Method::PUT).with(venues::update);
     })
     .resource("/venues", |r| {
-        r.middleware(CacheResource::new());
+        r.middleware(CacheResource::new(CacheUsersBy::AnonymousOnly));
         r.method(Method::GET).with(venues::index);
         r.method(Method::POST).with(venues::create);
     })
     .resource("/sitemap.xml", |r| {
-        r.middleware(CacheResource::new());
+        r.middleware(CacheResource::new(CacheUsersBy::None));
         r.method(Method::GET).with(sitemap_gen::index);
     })
     .register()

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -125,7 +125,7 @@ impl Server {
                                         .unwrap(),
                                 ])
                                 .allowed_header(http::header::CONTENT_TYPE)
-                                .expose_headers(vec!["x-app-version"])
+                                .expose_headers(vec!["x-app-version", "x-cached-response"])
                                 .max_age(3600);
 
                             routing::routes(&mut cors_config)

--- a/db/tests/unit/events.rs
+++ b/db/tests/unit/events.rs
@@ -1872,18 +1872,32 @@ fn guest_list() {
     let guest_list = event
         .guest_list(Some(order_id.clone()), &None, None, connection)
         .unwrap();
-    let guest_list_item = guest_list.0.first().unwrap();
-    assert_eq!(1, guest_list.1);
-    assert_eq!(normal_order.id, guest_list_item.ticket.order_id);
+    // Occasionally multiple orders have the same first few characters of their GUID leading to errors in test processing
+    assert!(guest_list.1 >= 1);
+
+    let mut found_guest_list_item = None;
+    for guest_list_item in guest_list.0 {
+        if guest_list_item.ticket.order_id == normal_order.id {
+            found_guest_list_item = Some(guest_list_item);
+        }
+    }
+    assert!(found_guest_list_item.is_some());
+
     //Search by ticket_instance id
     let ticket_id = first_ticket.id.to_string();
     let ticket_id = ticket_id[&ticket_id.len() - 8..].to_string();
     let guest_list = event
         .guest_list(Some(ticket_id.clone()), &None, None, connection)
         .unwrap();
-    let guest_list_item = guest_list.0.first().unwrap();
-    assert_eq!(1, guest_list.1);
-    assert_eq!(first_ticket.id, guest_list_item.ticket.id);
+    assert!(guest_list.1 >= 1);
+
+    let mut found_guest_list_item = None;
+    for guest_list_item in guest_list.0 {
+        if guest_list_item.ticket.id == first_ticket.id {
+            found_guest_list_item = Some(guest_list_item);
+        }
+    }
+    assert!(found_guest_list_item.is_some());
 }
 
 #[test]

--- a/db/tests/unit/events.rs
+++ b/db/tests/unit/events.rs
@@ -1877,6 +1877,12 @@ fn guest_list() {
 
     let mut found_guest_list_item = None;
     for guest_list_item in guest_list.0 {
+        assert_eq!(
+            order_id,
+            guest_list_item.ticket.order_id.to_string()[&guest_list_item.ticket.order_id.to_string().len() - 8..]
+                .to_string()
+        );
+
         if guest_list_item.ticket.order_id == normal_order.id {
             found_guest_list_item = Some(guest_list_item);
         }
@@ -1894,6 +1900,10 @@ fn guest_list() {
     let mut found_guest_list_item = None;
     for guest_list_item in guest_list.0 {
         if guest_list_item.ticket.id == first_ticket.id {
+            assert_eq!(
+                ticket_id,
+                guest_list_item.ticket.id.to_string()[&guest_list_item.ticket.id.to_string().len() - 8..].to_string()
+            );
             found_guest_list_item = Some(guest_list_item);
         }
     }


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1158142652422330/1163611145279329

### Description:

This branch modifies the previous caching approach to use middleware instead so it's more DRY. I've done it on the resource level (limiting to GET requests) so that we can have finer controller over which endpoints are cached. In the future we could expand the middleware to keep track of the caching duration, etc. if we wanted custom durations per endpoint as well.

Adding endpoint caching to the GET requests for the:
- artists search, show, index
- events show, index
- genres index
- regions show, index
- venues show, index
- sitemap

### Examples

Hitting the venues index endpoint:
```
curl http://localhost:9000/venues
{"data":[{"address":"address","city":"city","country":"the best country","created_at":"2020-02-25T20:01:55.651962","google_place_id":null,"id":"35b444ab-b76d-4992-8c4f-2612ab3472e0","is_private":false,"latitude":null,"longitude":null,"name":"Test venue_1582660906","phone":"5555555555","postal_code":"2222","promo_image_url":null,"region_id":null,"slug_id":"9330dc88-2b60-4bee-bdfc-935768f2ca3f","state":"CA","timezone":"America/Los_Angeles","updated_at":"2020-02-25T20:01:55.697736"}],"paging":{"dir":"Asc","limit":100,"page":0,"sort":"","tags":{},"total":1}}
```

Hitting it multiple times it's clear from the redis cli logs that if it fails to find the record it creates it with a timeout (currently set by env) and then subsequent requests pull that information and use it until it expires. Once it expires the subsequent request is stored, etc.
```
1582661929.209519 [0 127.0.0.1:54328] "GET" "{\"method\":\"GET\",\"path\":\"/venues\"}"
1582661929.212660 [0 127.0.0.1:54328] "PING"
1582661929.212750 [0 127.0.0.1:54328] "SET" "{\"method\":\"GET\",\"path\":\"/venues\"}" "{\"data\":[{\"id\":\"35b444ab-b76d-4992-8c4f-2612ab3472e0\",\"region_id\":null,\"is_private\":false,\"name\":\"Test venue_1582660906\",\"address\":\"address\",\"city\":\"city\",\"state\":\"CA\",\"country\":\"the best country\",\"postal_code\":\"2222\",\"phone\":\"5555555555\",\"promo_image_url\":null,\"created_at\":\"2020-02-25T20:01:55.651962\",\"updated_at\":\"2020-02-25T20:01:55.697736\",\"google_place_id\":null,\"latitude\":null,\"longitude\":null,\"timezone\":\"America/Los_Angeles\",\"slug_id\":\"9330dc88-2b60-4bee-bdfc-935768f2ca3f\"}],\"paging\":{\"page\":0,\"limit\":100,\"sort\":\"\",\"dir\":\"Asc\",\"total\":1,\"tags\":{}}}"
1582661929.212900 [0 127.0.0.1:54328] "PEXPIRE" "{\"method\":\"GET\",\"path\":\"/venues\"}" "10000"
1582661931.150821 [0 127.0.0.1:54328] "PING"
1582661931.150943 [0 127.0.0.1:54328] "GET" "{\"method\":\"GET\",\"path\":\"/venues\"}"
1582661932.062420 [0 127.0.0.1:54328] "PING"
1582661932.062554 [0 127.0.0.1:54328] "GET" "{\"method\":\"GET\",\"path\":\"/venues\"}"
1582661946.408116 [0 127.0.0.1:54328] "PING"
1582661946.408220 [0 127.0.0.1:54328] "GET" "{\"method\":\"GET\",\"path\":\"/venues\"}"
1582661946.409396 [0 127.0.0.1:54328] "PING"
1582661946.409488 [0 127.0.0.1:54328] "SET" "{\"method\":\"GET\",\"path\":\"/venues\"}" "{\"data\":[{\"id\":\"35b444ab-b76d-4992-8c4f-2612ab3472e0\",\"region_id\":null,\"is_private\":false,\"name\":\"Test venue_1582660906\",\"address\":\"address\",\"city\":\"city\",\"state\":\"CA\",\"country\":\"the best country\",\"postal_code\":\"2222\",\"phone\":\"5555555555\",\"promo_image_url\":null,\"created_at\":\"2020-02-25T20:01:55.651962\",\"updated_at\":\"2020-02-25T20:01:55.697736\",\"google_place_id\":null,\"latitude\":null,\"longitude\":null,\"timezone\":\"America/Los_Angeles\",\"slug_id\":\"9330dc88-2b60-4bee-bdfc-935768f2ca3f\"}],\"paging\":{\"page\":0,\"limit\":100,\"sort\":\"\",\"dir\":\"Asc\",\"total\":1,\"tags\":{}}}"
1582661946.409622 [0 127.0.0.1:54328] "PEXPIRE" "{\"method\":\"GET\",\"path\":\"/venues\"}" "10000"
1582661947.106461 [0 127.0.0.1:54328] "PING"
1582661947.106558 [0 127.0.0.1:54328] "GET" "{\"method\":\"GET\",\"path\":\"/venues\"}"
1582661947.981397 [0 127.0.0.1:54328] "PING"
1582661947.981548 [0 127.0.0.1:54328] "GET" "{\"method\":\"GET\",\"path\":\"/venues\"}"
```

This is also visible by looking at the response times via the dev console.

Without caching (first request):
<img width="543" alt="Screen Shot 2020-02-25 at 3 29 24 PM" src="https://user-images.githubusercontent.com/1319304/75284929-aa9f9800-57e3-11ea-8c09-8ea43a94f0d3.png">

Subsequent request:
<img width="497" alt="Screen Shot 2020-02-25 at 3 29 32 PM" src="https://user-images.githubusercontent.com/1319304/75284949-b0957900-57e3-11ea-8a9b-1156738c91b6.png">

## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
