### PR TITLE
Lockdown organization venues endpoint to correct resources

### DIFF
--- a/api/src/routing.rs
+++ b/api/src/routing.rs
@@ -285,7 +285,7 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
         r.method(Method::DELETE).with(organization_invites::destroy);
     })
     .resource("/organizations/{id}/organization_venues", |r| {
-        r.method(Method::GET).with(organization_venues::index);
+        r.method(Method::GET).with(organization_venues::organizations_index);
         r.method(Method::POST).with(organization_venues::create);
     })
     .resource("/organizations/{id}/settlements", |r| {
@@ -424,7 +424,7 @@ pub fn routes(app: &mut CorsBuilder<AppState>) -> App<AppState> {
         r.method(Method::GET).with(users::list_organizations);
     })
     .resource("/venues/{id}/organization_venues", |r| {
-        r.method(Method::GET).with(organization_venues::index);
+        r.method(Method::GET).with(organization_venues::venues_index);
         r.method(Method::POST).with(organization_venues::create);
     })
     .resource("/venues/{id}/stages", |r| {

--- a/api/tests/functional/organization_venues.rs
+++ b/api/tests/functional/organization_venues.rs
@@ -92,47 +92,47 @@ mod create_tests {
 }
 
 #[cfg(test)]
-mod index_venue_id_tests {
+mod venues_index_tests {
     use super::*;
     #[test]
-    fn index_venue_id_org_member() {
-        base::organization_venues::index(Roles::OrgMember, false, false);
+    fn venues_venues_index_org_member() {
+        base::organization_venues::venues_index(Roles::OrgMember, false);
     }
     #[test]
-    fn index_venue_id_admin() {
-        base::organization_venues::index(Roles::Admin, false, true);
+    fn venues_index_admin() {
+        base::organization_venues::venues_index(Roles::Admin, true);
     }
     #[test]
-    fn index_venue_id_super() {
-        base::organization_venues::index(Roles::Super, false, true);
+    fn venues_index_super() {
+        base::organization_venues::venues_index(Roles::Super, true);
     }
     #[test]
-    fn index_venue_id_user() {
-        base::organization_venues::index(Roles::User, false, false);
+    fn venues_index_user() {
+        base::organization_venues::venues_index(Roles::User, false);
     }
     #[test]
-    fn index_venue_id_org_owner() {
-        base::organization_venues::index(Roles::OrgOwner, false, false);
+    fn venues_index_org_owner() {
+        base::organization_venues::venues_index(Roles::OrgOwner, false);
     }
     #[test]
-    fn index_venue_id_door_person() {
-        base::organization_venues::index(Roles::DoorPerson, false, false);
+    fn venues_index_door_person() {
+        base::organization_venues::venues_index(Roles::DoorPerson, false);
     }
     #[test]
-    fn index_venue_id_promoter() {
-        base::organization_venues::index(Roles::Promoter, false, false);
+    fn venues_index_promoter() {
+        base::organization_venues::venues_index(Roles::Promoter, false);
     }
     #[test]
-    fn index_venue_id_promoter_read_only() {
-        base::organization_venues::index(Roles::PromoterReadOnly, false, false);
+    fn venues_index_promoter_read_only() {
+        base::organization_venues::venues_index(Roles::PromoterReadOnly, false);
     }
     #[test]
-    fn index_venue_id_org_admin() {
-        base::organization_venues::index(Roles::OrgAdmin, false, false);
+    fn venues_index_org_admin() {
+        base::organization_venues::venues_index(Roles::OrgAdmin, false);
     }
     #[test]
-    fn index_venue_id_box_office() {
-        base::organization_venues::index(Roles::OrgBoxOffice, false, false);
+    fn venues_index_box_office() {
+        base::organization_venues::venues_index(Roles::OrgBoxOffice, false);
     }
 }
 
@@ -140,44 +140,44 @@ mod index_venue_id_tests {
 mod index_organization_id_tests {
     use super::*;
     #[test]
-    fn index_organization_id_org_member() {
-        base::organization_venues::index(Roles::OrgMember, true, false);
+    fn organizations_index_org_member() {
+        base::organization_venues::organizations_index(Roles::OrgMember, false);
     }
     #[test]
-    fn index_organization_id_admin() {
-        base::organization_venues::index(Roles::Admin, true, true);
+    fn organizations_index_admin() {
+        base::organization_venues::organizations_index(Roles::Admin, true);
     }
     #[test]
-    fn index_organization_id_super() {
-        base::organization_venues::index(Roles::Super, true, true);
+    fn organizations_index_super() {
+        base::organization_venues::organizations_index(Roles::Super, true);
     }
     #[test]
-    fn index_organization_id_user() {
-        base::organization_venues::index(Roles::User, true, false);
+    fn organizations_index_user() {
+        base::organization_venues::organizations_index(Roles::User, false);
     }
     #[test]
-    fn index_organization_id_org_owner() {
-        base::organization_venues::index(Roles::OrgOwner, true, false);
+    fn organizations_index_org_owner() {
+        base::organization_venues::organizations_index(Roles::OrgOwner, false);
     }
     #[test]
-    fn index_organization_id_door_person() {
-        base::organization_venues::index(Roles::DoorPerson, true, false);
+    fn organizations_index_door_person() {
+        base::organization_venues::organizations_index(Roles::DoorPerson, false);
     }
     #[test]
-    fn index_organization_id_promoter() {
-        base::organization_venues::index(Roles::Promoter, true, false);
+    fn organizations_index_promoter() {
+        base::organization_venues::organizations_index(Roles::Promoter, false);
     }
     #[test]
-    fn index_organization_id_promoter_read_only() {
-        base::organization_venues::index(Roles::PromoterReadOnly, true, false);
+    fn organizations_index_promoter_read_only() {
+        base::organization_venues::organizations_index(Roles::PromoterReadOnly, false);
     }
     #[test]
-    fn index_organization_id_org_admin() {
-        base::organization_venues::index(Roles::OrgAdmin, true, false);
+    fn organizations_index_org_admin() {
+        base::organization_venues::organizations_index(Roles::OrgAdmin, false);
     }
     #[test]
-    fn index_organization_id_box_office() {
-        base::organization_venues::index(Roles::OrgBoxOffice, true, false);
+    fn organizations_index_box_office() {
+        base::organization_venues::organizations_index(Roles::OrgBoxOffice, false);
     }
 }
 

--- a/integration-tests/mocha/test/14 Redeeming/02 OrgMember - Get Guest List.js
+++ b/integration-tests/mocha/test/14 Redeeming/02 OrgMember - Get Guest List.js
@@ -57,7 +57,6 @@ describe('OrgMember - Get Guest List', function () {
     ;
 
     it("guests should be present", function () {
-
         let json = JSON.parse(responseBody);
         expect(json.data.length).to.be.greaterThan(6);
 


### PR DESCRIPTION
### References Issues:
N/A

### Description:
While debugging https://github.com/big-neon/bn-web/pull/2218 I saw that we were using the `/venues/{id}/organization_venues` endpoint but using an `organization_id` for the `id`. This worked because I didn't lock the endpoint down to specific resources but rather had both routes point to the endpoint and just assumed collisions wouldn't occur given how few of these records exist. 

This just modifies the logic to instead lockdown the resources for the `organization_venues`. It's a pretty simple change where we now just have two endpoints in place with their own lookups.

This shouldn't go out without https://github.com/big-neon/bn-web/pull/2218 first going out to no longer reference the wrong endpoint.

More of a debt card / not sure if we need QA to do anything here aside from normal site testing since these endpoints should not be in use at this time. The only other reference I see to these endpoints is here: https://github.com/big-neon/bn-web/blob/966a5faa52e7f5d2984147fb591e30b3d79f60c9/src/components/pages/admin/venues/Venue.js#L166 and it's properly using the `venueId` there so shouldn't be affected.

#### Examples

Trying to access an organization id for the venues endpoint:
```
curl http://localhost:9000/venues/61839b8b-a390-489c-9e4f-b4d138ebfdf2/organization_venues --header "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI4YzdhNmE3Zi01NDA4LTRjZGYtYTU0ZS1iYzUwYWIwOWE4NzUiLCJpc3MiOiJiZy1zYW1wbGUtaXNzdWVyIiwiZXhwIjoxNTgyNzU0ODA1fQ.i69J3gK1mwygqmKJ4WatXbN0Mj3MGH7z9trR-94LddI" -i
HTTP/1.1 404 Not Found
content-length: 22
content-type: application/json
access-control-allow-origin: http://localhost:3000
access-control-expose-headers: x-app-version
vary: Origin
x-app-version: 1.9.18
date: Wed, 26 Feb 2020 21:58:55 GMT

{"error":"No results"}
```

Properly referencing the venue id for the venues endpoint:
```
curl http://localhost:9000/venues/c7b85ece-999f-4edf-9ef8-5abd7f24fb1e/organization_venues --header "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI4YzdhNmE3Zi01NDA4LTRjZGYtYTU0ZS1iYzUwYWIwOWE4NzUiLCJpc3MiOiJiZy1zYW1wbGUtaXNzdWVyIiwiZXhwIjoxNTgyNzU0ODA1fQ.i69J3gK1mwygqmKJ4WatXbN0Mj3MGH7z9trR-94LddI" -i
HTTP/1.1 200 OK
content-length: 321
content-type: application/json
access-control-allow-origin: http://localhost:3000
access-control-expose-headers: x-app-version
vary: Origin
x-app-version: 1.9.18
date: Wed, 26 Feb 2020 21:59:02 GMT

{"data":[{"id":"07abd87a-2730-422f-83d7-194b2b8f2e23","organization_id":"61839b8b-a390-489c-9e4f-b4d138ebfdf2","venue_id":"c7b85ece-999f-4edf-9ef8-5abd7f24fb1e","created_at":"2020-02-26T20:40:19.859048","updated_at":"2020-02-26T20:40:19.859048"}],"paging":{"page":0,"limit":100,"sort":"","dir":"Asc","total":1,"tags":{}}}
```

Trying to access the organizations endpoint with a venueId:
```
curl http://localhost:9000/organizations/c7b85ece-999f-4edf-9ef8-5abd7f24fb1e/organization_venues --header "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI4YzdhNmE3Zi01NDA4LTRjZGYtYTU0ZS1iYzUwYWIwOWE4NzUiLCJpc3MiOiJiZy1zYW1wbGUtaXNzdWVyIiwiZXhwIjoxNTgyNzU0ODA1fQ.i69J3gK1mwygqmKJ4WatXbN0Mj3MGH7z9trR-94LddI" -i
HTTP/1.1 404 Not Found
content-length: 22
content-type: application/json
access-control-allow-origin: http://localhost:3000
access-control-expose-headers: x-app-version
vary: Origin
x-app-version: 1.9.18
date: Wed, 26 Feb 2020 21:59:06 GMT

{"error":"No results"}
```

Trying to access the organizations endpoint with the organizationId:
```
curl http://localhost:9000/organizations/61839b8b-a390-489c-9e4f-b4d138ebfdf2/organization_venues --header "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI4YzdhNmE3Zi01NDA4LTRjZGYtYTU0ZS1iYzUwYWIwOWE4NzUiLCJpc3MiOiJiZy1zYW1wbGUtaXNzdWVyIiwiZXhwIjoxNTgyNzU0ODA1fQ.i69J3gK1mwygqmKJ4WatXbN0Mj3MGH7z9trR-94LddI" -i
HTTP/1.1 200 OK
content-length: 795
content-type: application/json
access-control-allow-origin: http://localhost:3000
access-control-expose-headers: x-app-version
vary: Origin
x-app-version: 1.9.18
date: Wed, 26 Feb 2020 21:59:11 GMT

{"data":[{"id":"07abd87a-2730-422f-83d7-194b2b8f2e23","organization_id":"61839b8b-a390-489c-9e4f-b4d138ebfdf2","venue_id":"c7b85ece-999f-4edf-9ef8-5abd7f24fb1e","created_at":"2020-02-26T20:40:19.859048","updated_at":"2020-02-26T20:40:19.859048"},{"id":"650402bb-89e0-43c2-b6f2-9990f0584301","organization_id":"61839b8b-a390-489c-9e4f-b4d138ebfdf2","venue_id":"b07e8037-986d-4b1e-9618-911ba561793a","created_at":"2020-02-26T20:40:19.833824","updated_at":"2020-02-26T20:40:19.833824"},{"id":"95b3cb7e-9213-4f79-b884-9aff5ebb6641","organization_id":"61839b8b-a390-489c-9e4f-b4d138ebfdf2","venue_id":"2fae810c-273a-4413-af0c-161b6858de7a","created_at":"2020-02-26T20:40:30.050437","updated_at":"2020-02-26T20:40:30.050437"}],"paging":{"page":0,"limit":100,"sort":"","dir":"Asc","total":3,"tags":{}}}
```

## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
