### PR TITLE
Fix daylight savings time related issues with reporting

### DIFF
--- a/db/src/models/organizations.rs
+++ b/db/src/models/organizations.rs
@@ -321,20 +321,23 @@ impl Organization {
         // Else set as number of days from today
         if let Some(settlement_period) = settlement_period_in_days {
             let next_period = today.naive_local() + Duration::days(settlement_period as i64);
-            let next_date = timezone
+            Ok(timezone
                 .ymd(next_period.year(), next_period.month(), next_period.day())
                 .and_hms(start_hour, 0, 0)
-                .naive_utc();
-
-            Ok(next_date)
+                .naive_utc())
         } else {
-            let next_date = today.naive_utc()
+            let next_period_date = now
                 + Duration::days(
                     DEFAULT_SETTLEMENT_PERIOD_IN_DAYS - today.naive_local().weekday().num_days_from_monday() as i64,
+                );
+            Ok(timezone
+                .ymd(
+                    next_period_date.year(),
+                    next_period_date.month(),
+                    next_period_date.day(),
                 )
-                + Duration::hours(start_hour as i64);
-
-            Ok(next_date)
+                .and_hms(start_hour, 0, 0)
+                .naive_utc())
         }
     }
 

--- a/db/src/models/reports.rs
+++ b/db/src/models/reports.rs
@@ -2,7 +2,7 @@ use chrono::prelude::*;
 use chrono_tz::Tz;
 use diesel;
 use diesel::prelude::*;
-use diesel::sql_types::{BigInt, Bool, Nullable, Text, Timestamp, Time, Uuid as dUuid};
+use diesel::sql_types::{BigInt, Bool, Nullable, Text, Time, Timestamp, Uuid as dUuid};
 use itertools::Itertools;
 use models::*;
 use std::collections::HashMap;

--- a/db/src/models/reports.rs
+++ b/db/src/models/reports.rs
@@ -2,7 +2,7 @@ use chrono::prelude::*;
 use chrono_tz::Tz;
 use diesel;
 use diesel::prelude::*;
-use diesel::sql_types::{BigInt, Bool, Nullable, Text, Timestamp, Uuid as dUuid};
+use diesel::sql_types::{BigInt, Bool, Nullable, Text, Timestamp, Time, Uuid as dUuid};
 use itertools::Itertools;
 use models::*;
 use std::collections::HashMap;
@@ -11,7 +11,6 @@ use utils::errors::*;
 use uuid::Uuid;
 
 sql_function!(fn ticket_sales_per_ticket_pricing(start: Nullable<Timestamp>, end: Nullable<Timestamp>, group_by: Option<Text>) -> Vec<TicketSalesRow>);
-sql_function!(fn ticket_count_per_ticket_type(event_id: Nullable<dUuid>, organization_id: Nullable<dUuid>, group_by: Option<Text>) -> Vec<TicketCountRow>);
 pub struct Report {}
 
 #[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, QueryableByName)]
@@ -565,18 +564,24 @@ impl TicketCountRow {
         group_by_ticket_type: bool,
         conn: &PgConnection,
     ) -> Result<Vec<TicketCountRow>, DatabaseError> {
+        let timezone = "America/Los_Angeles"
+            .parse::<Tz>()
+            .map_err(|e| DatabaseError::business_process_error::<Tz>(&e).unwrap_err())?;
+        let now = Utc::now().naive_utc();
+        let four_am_pacific = timezone
+            .ymd(now.year(), now.month(), now.day())
+            .and_hms(4, 0, 0)
+            .naive_utc()
+            .time();
         let group_by = group_by_string(group_by_ticket_type, false, false, group_by_event);
         let query_ticket_counts = include_str!("../queries/reports/reports_tickets_counts.sql");
-        let q = diesel::sql_query(query_ticket_counts)
+        diesel::sql_query(query_ticket_counts)
             .bind::<Nullable<dUuid>, _>(event_id)
             .bind::<Nullable<dUuid>, _>(organization_id)
-            .bind::<Nullable<Text>, _>(group_by);
-
-        let rows: Vec<TicketCountRow> = q
+            .bind::<Nullable<Text>, _>(group_by)
+            .bind::<Time, _>(four_am_pacific)
             .get_results(conn)
-            .to_db_error(ErrorCode::QueryError, "Could not fetch ticket counts")?;
-
-        Ok(rows)
+            .to_db_error(ErrorCode::QueryError, "Could not fetch ticket counts")
     }
 }
 
@@ -619,11 +624,11 @@ impl Report {
             .map_err(|e| DatabaseError::business_process_error::<Tz>(&e).unwrap_err())?;
         let now = timezone.from_utc_datetime(&Utc::now().naive_utc());
         // 4 AM tomorrow PT
+        let tomorrow = now + Duration::days(1);
         Ok(timezone
-            .ymd(now.year(), now.month(), now.day())
+            .ymd(tomorrow.year(), tomorrow.month(), tomorrow.day())
             .and_hms(4, 0, 0)
-            .naive_utc()
-            + Duration::days(1))
+            .naive_utc())
     }
 
     pub fn create_next_automatic_report_domain_action(conn: &PgConnection) -> Result<(), DatabaseError> {

--- a/db/src/queries/reports/reports_tickets_counts.sql
+++ b/db/src/queries/reports/reports_tickets_counts.sql
@@ -1,1 +1,1 @@
-SELECT * FROM ticket_count_per_ticket_type($1, $2, $3);
+SELECT * FROM ticket_count_per_ticket_type($1, $2, $3, $4);

--- a/db/tests/unit/organizations.rs
+++ b/db/tests/unit/organizations.rs
@@ -205,15 +205,28 @@ fn next_settlement_date() {
     let pt_timezone: Tz = "America/Los_Angeles".parse().unwrap();
     let now = pt_timezone.from_utc_datetime(&Utc::now().naive_utc());
     let pt_today = pt_timezone.ymd(now.year(), now.month(), now.day()).and_hms(0, 0, 0);
-    let expected_pt = pt_today.naive_utc()
-        + Duration::days(7 - pt_today.naive_local().weekday().num_days_from_monday() as i64)
-        + Duration::hours(3);
+    let next_period_date = now + Duration::days(7 - pt_today.naive_local().weekday().num_days_from_monday() as i64);
+    let expected_pt = pt_timezone
+        .ymd(
+            next_period_date.year(),
+            next_period_date.month(),
+            next_period_date.day(),
+        )
+        .and_hms(3, 0, 0)
+        .naive_utc();
+
     let sa_timezone: Tz = "Africa/Johannesburg".parse().unwrap();
     let now = sa_timezone.from_utc_datetime(&Utc::now().naive_utc());
     let sa_today = sa_timezone.ymd(now.year(), now.month(), now.day()).and_hms(0, 0, 0);
-    let expected_sa = sa_today.naive_utc()
-        + Duration::days(7 - sa_today.naive_local().weekday().num_days_from_monday() as i64)
-        + Duration::hours(3);
+    let next_period_date = now + Duration::days(7 - sa_today.naive_local().weekday().num_days_from_monday() as i64);
+    let expected_sa = sa_timezone
+        .ymd(
+            next_period_date.year(),
+            next_period_date.month(),
+            next_period_date.day(),
+        )
+        .and_hms(3, 0, 0)
+        .naive_utc();
 
     // Default behavior no timezone, upcoming Monday 3:00 AM PT
     assert_eq!(organization.next_settlement_date(None).unwrap(), expected_pt);
@@ -233,8 +246,14 @@ fn next_settlement_date() {
     assert_eq!(organization.next_settlement_date(None).unwrap(), expected_sa);
 
     // Switch to rolling which always uses PT
-    let expected_pt =
-        pt_today.naive_utc() + Duration::days(7 - pt_today.naive_local().weekday().num_days_from_monday() as i64);
+    let expected_pt = pt_timezone
+        .ymd(
+            next_period_date.year(),
+            next_period_date.month(),
+            next_period_date.day(),
+        )
+        .and_hms(0, 0, 0)
+        .naive_utc();
     let organization = organization
         .update(
             OrganizationEditableAttributes {
@@ -249,9 +268,14 @@ fn next_settlement_date() {
     assert_eq!(organization.next_settlement_date(None).unwrap(), expected_pt);
 
     // Override organization timezone to PT and switch back to PostEvent
-    let expected_pt = pt_today.naive_utc()
-        + Duration::days(7 - pt_today.naive_local().weekday().num_days_from_monday() as i64)
-        + Duration::hours(3);
+    let expected_pt = pt_timezone
+        .ymd(
+            next_period_date.year(),
+            next_period_date.month(),
+            next_period_date.day(),
+        )
+        .and_hms(3, 0, 0)
+        .naive_utc();
     let organization = organization
         .update(
             OrganizationEditableAttributes {
@@ -267,7 +291,15 @@ fn next_settlement_date() {
     assert_eq!(organization.next_settlement_date(None).unwrap(), expected_pt);
 
     // Using a passed in settlement period
-    let expected_pt = pt_today.naive_utc() + Duration::days(1) + Duration::hours(3);
+    let next_period_date = now + Duration::days(1);
+    let expected_pt = pt_timezone
+        .ymd(
+            next_period_date.year(),
+            next_period_date.month(),
+            next_period_date.day(),
+        )
+        .and_hms(3, 0, 0)
+        .naive_utc();
     assert_eq!(organization.next_settlement_date(Some(1)).unwrap(), expected_pt);
 
     let organization = organization
@@ -281,7 +313,15 @@ fn next_settlement_date() {
             connection,
         )
         .unwrap();
-    let expected_sa = sa_today.naive_utc() + Duration::days(1) + Duration::hours(3);
+
+    let expected_sa = sa_timezone
+        .ymd(
+            next_period_date.year(),
+            next_period_date.month(),
+            next_period_date.day(),
+        )
+        .and_hms(3, 0, 0)
+        .naive_utc();
     assert_eq!(organization.next_settlement_date(Some(1)).unwrap(), expected_sa);
 
     // Rolling with passed in settlement period
@@ -296,7 +336,14 @@ fn next_settlement_date() {
             connection,
         )
         .unwrap();
-    let expected_pt = pt_today.naive_utc() + Duration::days(1);
+    let expected_pt = pt_timezone
+        .ymd(
+            next_period_date.year(),
+            next_period_date.month(),
+            next_period_date.day(),
+        )
+        .and_hms(0, 0, 0)
+        .naive_utc();
     assert_eq!(organization.next_settlement_date(Some(1)).unwrap(), expected_pt);
 }
 

--- a/db/tests/unit/reports.rs
+++ b/db/tests/unit/reports.rs
@@ -142,8 +142,12 @@ fn next_automatic_report_date() {
     let organization = project.create_organization().finish();
     let pt_timezone: Tz = "America/Los_Angeles".parse().unwrap();
     let now = pt_timezone.from_utc_datetime(&Utc::now().naive_utc());
-    let pt_today = pt_timezone.ymd(now.year(), now.month(), now.day()).and_hms(4, 0, 0);
-    let expected = pt_today.naive_utc() + Duration::days(1);
+    let pt_today = pt_timezone.ymd(now.year(), now.month(), now.day()).and_hms(0, 0, 0);
+    let tomorrow = pt_today.naive_utc() + Duration::days(1);
+    let expected = pt_timezone
+        .ymd(tomorrow.year(), tomorrow.month(), tomorrow.day())
+        .and_hms(4, 0, 0)
+        .naive_utc();
     assert_eq!(Report::next_automatic_report_date().unwrap(), expected);
 
     // Organization timezone has no effect on the date


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/657855478437518/1152528192159785/f

### Description:
This fixes:
- Automatic ticket count report email: next date added the hours prior to adding the days so it would get midnight, add 3 hours, and then add a week causing it to run at an incorrect hour.
- Automatic ticket count report email: previously the hour of the day in UTC was hardcoded now it is passed in when the query is run so that it respects if daylight savings is current ongoing
- Adjusts settlements report creation so that it properly adds the week prior to creating the date in the local timezone. Previously it would get the time and then add the week so with daylight savings the next date was an hour early.

I did not notice any issues with the other reports as we pass time in as UTC so it shouldn't be an issue. I searched for code like the ones here to find any that may make a new domain action at a given time but didn't see any others in my results. 

#### Examples

Rolling organizations have settlement job created with timezone in mind:
```
update organizations set settlement_type = 'Rolling';
UPDATE 1
delete from domain_actions where domain_action_type = 'ProcessSettlementReport' and status = 'Pending';
DELETE 1

select * from domain_actions where domain_action_type = 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 c975021c-c4f5-436a-8067-45ff990e8bb2 |                 | ProcessSettlementReport |                            | {}      | Organizations | de74550f-e641-4edc-9138-3968a8d3a646 | 2020-03-09 07:00:00 | 2020-03-09 07:15:00.000003 |                   |             0 |                 3 | Pending |                     | 2020-03-09 06:59:30.000005 | 2020-03-04 17:38:33.545255 | 2020-03-04 17:38:33.545255
(1 row)
```

Post event settlements do as well:
```
update organizations set settlement_type = 'PostEvent';
UPDATE 1
delete from domain_actions where domain_action_type = 'ProcessSettlementReport' and status = 'Pending';
DELETE 1

select * from domain_actions where domain_action_type = 'ProcessSettlementReport' and status = 'Pending';
                  id                  | domain_event_id |   domain_action_type    | communication_channel_type | payload |  main_table   |            main_table_id             |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+-------------------------+----------------------------+---------+---------------+--------------------------------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 ecfaef39-29e9-4cbd-ad2c-bd79fb560c7c |                 | ProcessSettlementReport |                            | {}      | Organizations | de74550f-e641-4edc-9138-3968a8d3a646 | 2020-03-09 10:00:00 | 2020-03-09 10:15:00.000002 |                   |             0 |                 3 | Pending |                     | 2020-03-09 09:59:30.000005 | 2020-03-04 17:39:59.990308 | 2020-03-04 17:39:59.990308
(1 row)
```

## Release Details:

It is likely worth recreating the next settlement job for organizations as it is set to run an hour early right now:

```
delete from domain_actions where domain_action_type = 'ProcessSettlementReport' and status = 'Pending';
```

And then run: `cargo run --bin api-cli schedule-missing-domain-actions`

### Migrations
 * No Migrations

### Environment Variables
 * No change
