### PR TITLE
Fix issue with caching and resources

### DIFF
--- a/api/src/middleware/cache_resource.rs
+++ b/api/src/middleware/cache_resource.rs
@@ -64,11 +64,7 @@ impl Middleware<AppState> for CacheResource {
             for (key, value) in query_parameters.iter() {
                 query.insert(key, value.to_string());
             }
-            let resource_def = resource.rdef().clone();
-            if resource_def.is_none() {
-                return Ok(Started::Done);
-            }
-            let path = resource_def.unwrap().pattern().to_string();
+            let path = request.path().to_string();
             let path_text = "path".to_string();
             let method = request.method().to_string();
             let method_text = "method".to_string();
@@ -143,11 +139,7 @@ impl Middleware<AppState> for CacheResource {
                     for (key, value) in query_parameters.iter() {
                         query.insert(key, value.to_string());
                     }
-                    let resource_def = resource.rdef().clone();
-                    if resource_def.is_none() {
-                        return Ok(Response::Done(response));
-                    }
-                    let path = resource_def.unwrap().pattern().to_string();
+                    let path = request.path().to_string();
                     let path_text = "path".to_string();
                     let method = request.method().to_string();
                     let method_text = "method".to_string();

--- a/api/src/middleware/cache_resource.rs
+++ b/api/src/middleware/cache_resource.rs
@@ -59,7 +59,6 @@ impl Middleware<AppState> for CacheResource {
         let mut cache_configuration = CacheConfiguration::new();
         if request.method() == Method::GET {
             let mut query = BTreeMap::new();
-            let resource = request.resource().clone();
             let query_parameters = request.query().clone();
             for (key, value) in query_parameters.iter() {
                 query.insert(key, value.to_string());
@@ -134,7 +133,6 @@ impl Middleware<AppState> for CacheResource {
                 if cache_configuration.cache_response {
                     let cache_database = state.database.cache_database.clone();
                     let mut query = BTreeMap::new();
-                    let resource = request.resource().clone();
                     let query_parameters = request.query();
                     for (key, value) in query_parameters.iter() {
                         query.insert(key, value.to_string());


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1158142652422330/1163611145279329

### Description:
I noticed a bug with the caching -- it's not differentiating the resources right now. It's caching the path as the resource definition: ie: `/venues/{id}` so the first response is cached.

With the change the correct cache is stored:
```
1583358959.947735 [0 127.0.0.1:53300] "GET" "{\"method\":\"GET\",\"path\":\"/events/503fe110-94c0-4eb8-8a12-97e0ef80e124\",\"x-user-role\":\"User,Admin,Super\"}"
1583358960.363148 [0 127.0.0.1:53300] "PING"
1583358960.363277 [0 127.0.0.1:53300] "GET" "{\"method\":\"GET\",\"path\":\"/venues/ae399d3d-f952-4348-bbd5-39436cdefc44\"}"
1583358960.364644 [0 127.0.0.1:53300] "PING"
1583358960.364774 [0 127.0.0.1:53300] "SET" "{\"method\":\"GET\",\"path\":\"/venues/ae399d3d-f952-4348-bbd5-39436cdefc44\",\"x-user-role\":\"\"}" "{\"id\":\"ae399d3d-f952-4348-bbd5-39436cdefc44\",\"region_id\":null,\"is_private\":false,\"name\":\"Test venue_1583354243\",\"address\":\"address\",\"city\":\"city\",\"state\":\"CA\",\"country\":\"the best country\",\"postal_code\":\"2222\",\"phone\":\"5555555555\",\"promo_image_url\":null,\"created_at\":\"2020-03-04T20:37:32.948686\",\"updated_at\":\"2020-03-04T20:37:33.013064\",\"google_place_id\":null,\"latitude\":null,\"longitude\":null,\"timezone\":\"America/Los_Angeles\",\"slug_id\":\"65bcb123-4abc-45d1-9dc1-cd77394dcee8\"}"
1583358960.364927 [0 127.0.0.1:53300] "PEXPIRE" "{\"method\":\"GET\",\"path\":\"/venues/ae399d3d-f952-4348-bbd5-39436cdefc44\",\"x-user-role\":\"\"}" "30000"
```

## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
