### PR TITLE
Fix settlement finalization job for dst

### DIFF
--- a/db/src/models/settlements.rs
+++ b/db/src/models/settlements.rs
@@ -146,20 +146,31 @@ impl Settlement {
         let now = timezone.from_utc_datetime(&Utc::now().naive_utc());
         let today = timezone.ymd(now.year(), now.month(), now.day()).and_hms(0, 0, 0);
         let days_since_monday = today.naive_local().weekday().num_days_from_monday();
-        let next_action_date = if days_since_monday < 2 || (days_since_monday == 2 && now.naive_local().hour() < 12) {
-            today.naive_utc()
-                + Duration::days(2 - today.naive_local().weekday().num_days_from_monday() as i64)
-                + Duration::hours(12)
+        if days_since_monday < 2 || (days_since_monday == 2 && now.naive_local().hour() < 12) {
+            let next_period_date = now + Duration::days(2 - days_since_monday as i64);
+            Ok(timezone
+                .ymd(
+                    next_period_date.year(),
+                    next_period_date.month(),
+                    next_period_date.day(),
+                )
+                .and_hms(12, 0, 0)
+                .naive_utc())
         } else {
-            today.naive_utc()
+            let next_period_date = now
                 + Duration::days(
                     // Week - days since Monday + 2 days (Mon -> Wed)
                     7 - today.naive_local().weekday().num_days_from_monday() as i64 + 2,
+                );
+            Ok(timezone
+                .ymd(
+                    next_period_date.year(),
+                    next_period_date.month(),
+                    next_period_date.day(),
                 )
-                + Duration::hours(12)
-        };
-
-        Ok(next_action_date)
+                .and_hms(12, 0, 0)
+                .naive_utc())
+        }
     }
 
     pub fn find_last_settlement_for_organization(

--- a/db/tests/unit/settlements.rs
+++ b/db/tests/unit/settlements.rs
@@ -53,14 +53,20 @@ fn next_finalization_date() {
     let now = pt_timezone.from_utc_datetime(&Utc::now().naive_utc());
     let pt_today = pt_timezone.ymd(now.year(), now.month(), now.day()).and_hms(0, 0, 0);
     let days_since_monday = pt_today.naive_local().weekday().num_days_from_monday();
+
+    let this_wednesday = now + Duration::days(2 - pt_today.naive_local().weekday().num_days_from_monday() as i64);
+    let next_wednesday = now + Duration::days(7 - pt_today.naive_local().weekday().num_days_from_monday() as i64 + 2);
+
     let expected_pt = if days_since_monday < 2 || (days_since_monday == 2 && now.naive_local().hour() < 12) {
-        pt_today.naive_utc()
-            + Duration::days(2 - pt_today.naive_local().weekday().num_days_from_monday() as i64)
-            + Duration::hours(12)
+        pt_timezone
+            .ymd(this_wednesday.year(), this_wednesday.month(), this_wednesday.day())
+            .and_hms(12, 0, 0)
+            .naive_utc()
     } else {
-        pt_today.naive_utc()
-            + Duration::days(7 - pt_today.naive_local().weekday().num_days_from_monday() as i64 + 2)
-            + Duration::hours(12)
+        pt_timezone
+            .ymd(next_wednesday.year(), next_wednesday.month(), next_wednesday.day())
+            .and_hms(12, 0, 0)
+            .naive_utc()
     };
 
     assert_eq!(Settlement::next_finalization_date().unwrap(), expected_pt);


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1158142652422330/1164024375193057

### Description:
This merged in around the same time as the daylight savings time fixes. It was missed as a result in the set of logic updated to fix this bug. The problem was the logic took the current date at midnight, added a week, and then added the hours so it was at an incorrect date the following week.

I've adjusted my system clock and tested setting these -- it's clear from the below that the correct scheduled at is now set per week:
```
select * from domain_actions where domain_action_type = 'FinalizeSettlements';
                  id                  | domain_event_id | domain_action_type  | communication_channel_type | payload | main_table | main_table_id |    scheduled_at     |         expires_at         | last_attempted_at | attempt_count | max_attempt_count | status  | last_failure_reason |       blocked_until        |         created_at         |         updated_at         
--------------------------------------+-----------------+---------------------+----------------------------+---------+------------+---------------+---------------------+----------------------------+-------------------+---------------+-------------------+---------+---------------------+----------------------------+----------------------------+----------------------------
 e4ff8e61-e493-4513-926e-7c4aa9f97427 |                 | FinalizeSettlements |                            | {}      |            |               | 2020-02-26 20:00:00 | 2020-02-26 20:15:00.000001 |                   |             0 |                 3 | Success |                     | 2020-02-26 20:01:00.196699 | 2020-02-26 19:59:24.853891 | 2020-02-26 20:00:00.200507
 d72524c2-3954-4f48-bc33-c46555d9cc48 |                 | FinalizeSettlements |                            | {}      |            |               | 2020-03-04 20:00:00 | 2020-03-04 20:15:00.000003 |                   |             0 |                 3 | Success |                     | 2020-03-04 20:01:28.036877 | 2020-02-26 20:00:00.200507 | 2020-03-04 20:00:28.038638
 f1fed7b5-011f-4ef2-894b-c0f8af881989 |                 | FinalizeSettlements |                            | {}      |            |               | 2020-03-18 19:00:00 | 2020-03-18 19:15:00.000002 |                   |             0 |                 3 | Pending |                     | 2020-03-18 18:59:30.000005 | 2020-03-11 19:00:44.238943 | 2020-03-11 19:00:44.238943
 06c5ad2c-f096-4b14-bb09-dc27a703ce1a |                 | FinalizeSettlements |                            | {}      |            |               | 2020-03-11 19:00:00 | 2020-03-11 19:15:00.000001 |                   |             0 |                 3 | Success |                     | 2020-03-11 19:01:44.237718 | 2020-03-04 20:00:28.038638 | 2020-03-11 19:00:44.238943
(4 rows)

```

## Release Details:

Worth deleting the existing job and recreating just to confirm it properly finalizes these at the correct hour:
```
delete from domain_actions where domain_action_type = 'FinalizeSettlements' and status = 'Pending';
```

And then recreating:

```
api-cli schedule-missing-domain-actions
```

### Migrations
 * No Migrations

### Environment Variables
 * No change
