### PR TITLE
Remove cancelled ticket types from scan counts report

### DIFF
--- a/db/src/queries/reports/reports_scan_counts.sql
+++ b/db/src/queries/reports/reports_scan_counts.sql
@@ -1,6 +1,6 @@
 SELECT
   COUNT(*) OVER ()                                                                          AS total,
-  CASE WHEN tt.status = 'Cancelled' THEN concat(tt.name, ' (Cancelled)') ELSE tt.name END   AS ticket_type_name,
+  tt.name                                                                                   AS ticket_type_name,
   CAST(COALESCE(COUNT(DISTINCT ti.id) FILTER(WHERE ti.status = 'Redeemed'), 0) AS BIGINT)   AS scanned_count,
   CAST(COALESCE(COUNT(DISTINCT ti.id) FILTER(WHERE ti.status = 'Purchased'), 0) AS BIGINT)  AS not_scanned_count
 FROM ticket_types tt
@@ -9,6 +9,7 @@ LEFT JOIN ticket_instances ti ON a.id = ti.asset_id
 -- Confirm this isn't a refunded redeemed (they keep their redeemed status and order association unlike normal refunds)
 LEFT JOIN refunded_tickets rt ON rt.ticket_instance_id = ti.id AND ti.order_item_id = rt.order_item_id
 WHERE tt.event_id = $1
+AND tt.status <> 'Cancelled'
 AND rt.id IS NULL
 GROUP BY tt.name, tt.rank, tt.status
 ORDER BY tt.rank;


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1158142652422330/1108664757209900

### Description:
With #1714 most of the scan report is set. There was a change request by Jessi to remove the cancelled ticket types so I've made that change here. It's a fairly simple change just to remove the custom naming the logic had in place for cancelled and to filter those records out.

Example (continues examples from #1714) showing that the cancelled type is no longer included:
```
curl --header "Content-Type: application/json" "http://localhost:9000/reports/800da891-cbf2-4999-a932-61927e15676a?report=scan_count&event_id=4b0c37ea-1e1d-4ba7-948c-35866ec797a3" --header "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhOTA5YWZhNy01ODNkLTRlOTAtYTE2Mi1mMGFhYmE2MDIxMzkiLCJpc3MiOiJiZy1zYW1wbGUtaXNzdWVyIiwiZXhwIjoxNTg0MTEwNTQ2fQ.7OjBf_lxRhnMND_7xsmkenxyJCcfeLpRHzA_qGwuU3s" -i
HTTP/1.1 200 OK
content-length: 439
content-type: application/json
access-control-allow-origin: http://localhost:3000
access-control-expose-headers: x-cached-response, x-app-version
vary: Origin
x-app-version: 1.9.34
date: Fri, 13 Mar 2020 14:27:58 GMT

{"data":[{"ticket_type_name":"Default_Pricing_1583858227","scanned_count":0,"not_scanned_count":0},{"ticket_type_name":"VIP_1583858227","scanned_count":0,"not_scanned_count":4},{"ticket_type_name":"VIP_1583858227_With_Box_Office","scanned_count":0,"not_scanned_count":0},{"ticket_type_name":"General Admission_1583858227","scanned_count":2,"not_scanned_count":62}],"paging":{"page":0,"limit":100,"sort":"","dir":"Asc","total":4,"tags":{}}}
```
## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
