### PR TITLE
Toggleable refund access by organization

### DIFF
--- a/api/src/controllers/orders.rs
+++ b/api/src/controllers/orders.rs
@@ -152,7 +152,7 @@ pub fn details((conn, path, user): (Connection, Path<PathParameters>, User)) -> 
     }
 
     Ok(HttpResponse::Ok().json(DetailsResponse {
-        items: order.details(&organization_ids, user.id(), connection)?,
+        items: order.details(&organization_ids, &user.user, connection)?,
         order_contains_other_tickets: order.partially_visible_order(&organization_ids, user.id(), connection)?,
     }))
 }
@@ -436,7 +436,10 @@ fn is_authorized_to_refund(
                 &organization,
                 event.id,
                 connection,
-            )? {
+            )? || (!user.user.is_admin() && !manual_override && !organization.is_allowed_to_refund)
+            {
+                // User does not have access to organization event being refunded
+                // or user is not admin, this is a normal refund, and the organization is not allowed to refund
                 authorized_to_refund_items = false;
                 break;
             }

--- a/api/src/controllers/organizations.rs
+++ b/api/src/controllers/organizations.rs
@@ -58,6 +58,7 @@ pub struct NewOrganizationRequest {
     pub cc_fee_percent: Option<f32>,
     pub max_instances_per_ticket_type: Option<i64>,
     pub settlement_type: Option<SettlementTypes>,
+    pub is_allowed_to_refund: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -151,6 +152,7 @@ pub fn create(
             None => state.config.max_instances_per_ticket_type,
         }),
         settlement_type: new_organization.settlement_type,
+        is_allowed_to_refund: new_organization.is_allowed_to_refund,
     };
 
     let mut organization = new_organization_with_fee_schedule.commit(

--- a/api/tests/functional/base/orders.rs
+++ b/api/tests/functional/base/orders.rs
@@ -218,7 +218,12 @@ pub fn details(role: Roles, should_succeed: bool) {
     let database = TestDatabase::new();
     let connection = database.connection.get();
     let user = database.create_user().finish();
-    let organization = database.create_organization().with_event_fee().with_fees().finish();
+    let organization = database
+        .create_organization()
+        .is_allowed_to_refund()
+        .with_event_fee()
+        .with_fees()
+        .finish();
     let event = database
         .create_event()
         .with_organization(&organization)
@@ -367,7 +372,12 @@ pub fn details(role: Roles, should_succeed: bool) {
 pub fn refund(role: Roles, manual_override: bool, should_succeed: bool) {
     let database = TestDatabase::new();
     let connection = database.connection.get();
-    let organization = database.create_organization().with_event_fee().with_fees().finish();
+    let organization = database
+        .create_organization()
+        .is_allowed_to_refund()
+        .with_event_fee()
+        .with_fees()
+        .finish();
     let event = database
         .create_event()
         .with_organization(&organization)

--- a/api/tests/functional/base/organizations.rs
+++ b/api/tests/functional/base/organizations.rs
@@ -177,6 +177,7 @@ pub fn create(role: Roles, should_test_succeed: bool) {
         globee_api_key: None,
         max_instances_per_ticket_type: Some(11000),
         settlement_type: None,
+        is_allowed_to_refund: None,
     });
 
     let test_request = TestRequest::create_with_uri("/organizations");

--- a/db/migrations/20200316174006_add_is_allowed_to_refund_to_organizations/down.sql
+++ b/db/migrations/20200316174006_add_is_allowed_to_refund_to_organizations/down.sql
@@ -1,0 +1,2 @@
+Alter table organizations
+    drop is_allowed_to_refund;

--- a/db/migrations/20200316174006_add_is_allowed_to_refund_to_organizations/up.sql
+++ b/db/migrations/20200316174006_add_is_allowed_to_refund_to_organizations/up.sql
@@ -1,0 +1,2 @@
+alter table organizations
+  add is_allowed_to_refund boolean not null default 'f';

--- a/db/src/models/orders.rs
+++ b/db/src/models/orders.rs
@@ -707,14 +707,15 @@ impl Order {
     pub fn details(
         &self,
         organization_ids: &Vec<Uuid>,
-        user_id: Uuid,
+        user: &User,
         conn: &PgConnection,
     ) -> Result<Vec<OrderDetailsLineItem>, DatabaseError> {
         let query = include_str!("../queries/order_details.sql");
         diesel::sql_query(query)
             .bind::<dUuid, _>(self.id)
             .bind::<Array<dUuid>, _>(organization_ids)
-            .bind::<dUuid, _>(user_id)
+            .bind::<dUuid, _>(user.id)
+            .bind::<Bool, _>(user.is_admin())
             .load(conn)
             .to_db_error(ErrorCode::QueryError, "Could not load order details")
     }

--- a/db/src/models/organizations.rs
+++ b/db/src/models/organizations.rs
@@ -54,6 +54,7 @@ pub struct Organization {
     pub slug_id: Option<Uuid>,
     pub google_ads_conversion_id: Option<String>,
     pub google_ads_conversion_labels: Vec<String>,
+    pub is_allowed_to_refund: bool,
 }
 
 #[derive(Serialize)]
@@ -90,6 +91,7 @@ pub struct NewOrganization {
     pub globee_api_key: Option<String>,
     pub max_instances_per_ticket_type: Option<i64>,
     pub settlement_type: Option<SettlementTypes>,
+    pub is_allowed_to_refund: Option<bool>,
 }
 
 #[derive(Default, Serialize, Clone, Deserialize, Debug, PartialEq)]
@@ -214,6 +216,7 @@ pub struct OrganizationEditableAttributes {
     pub google_ads_conversion_id: Option<Option<String>>,
     #[serde(default)]
     pub google_ads_conversion_labels: Option<Vec<String>>,
+    pub is_allowed_to_refund: Option<bool>,
 }
 
 impl Organization {

--- a/db/src/queries/order_details.sql
+++ b/db/src/queries/order_details.sql
@@ -5,7 +5,7 @@ SELECT ticket_instance_id,
        fees_price_in_cents,
        (ticket_price_in_cents + fees_price_in_cents) AS total_price_in_cents,
        status,
-       status IN ('Purchased', 'Redeemed') AS refundable,
+       status IN ('Purchased', 'Redeemed') AND (is_allowed_to_refund OR $4) AS refundable,
        CASE WHEN status <> 'Refunded' THEN attendee_email ELSE NULL END AS attendee_email,
        CASE WHEN status <> 'Refunded' THEN attendee_id ELSE NULL END AS attendee_id,
        CASE WHEN status <> 'Refunded' THEN attendee_first_name ELSE NULL END AS attendee_first_name,
@@ -52,7 +52,8 @@ FROM (
                 coalesce(h.redemption_code, c.redemption_code)           AS code,
                 coalesce(h.hold_type, c.code_type) AS code_type,
                 tfs.id                             AS pending_transfer_id,
-                dis.unit_price_in_cents            AS discount_price_in_cents
+                dis.unit_price_in_cents            AS discount_price_in_cents,
+                orgs.is_allowed_to_refund          AS is_allowed_to_refund
 
          FROM (
                   SELECT DISTINCT ticket_instance_id, order_item_id

--- a/db/src/schema.rs
+++ b/db/src/schema.rs
@@ -218,6 +218,17 @@ table! {
 }
 
 table! {
+    event_users (id) {
+        id -> Uuid,
+        user_id -> Uuid,
+        event_id -> Uuid,
+        role -> Text,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+table! {
     events (id) {
         id -> Uuid,
         name -> Text,
@@ -254,17 +265,6 @@ table! {
         facebook_event_id -> Nullable<Text>,
         settled_at -> Nullable<Timestamp>,
         cloned_from_event_id -> Nullable<Uuid>,
-    }
-}
-
-table! {
-    event_users (id) {
-        id -> Uuid,
-        user_id -> Uuid,
-        event_id -> Uuid,
-        role -> Text,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
     }
 }
 
@@ -372,6 +372,16 @@ table! {
 }
 
 table! {
+    order_transfers (id) {
+        id -> Uuid,
+        order_id -> Uuid,
+        transfer_id -> Uuid,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+table! {
     orders (id) {
         id -> Uuid,
         user_id -> Uuid,
@@ -399,16 +409,6 @@ table! {
         platform -> Nullable<Text>,
         settlement_id -> Nullable<Uuid>,
         referrer -> Nullable<Text>,
-    }
-}
-
-table! {
-    order_transfers (id) {
-        id -> Uuid,
-        order_id -> Uuid,
-        transfer_id -> Uuid,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
     }
 }
 
@@ -443,6 +443,27 @@ table! {
 }
 
 table! {
+    organization_users (id) {
+        id -> Uuid,
+        organization_id -> Uuid,
+        user_id -> Uuid,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+        role -> Array<Text>,
+    }
+}
+
+table! {
+    organization_venues (id) {
+        id -> Uuid,
+        organization_id -> Uuid,
+        venue_id -> Uuid,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+table! {
     organizations (id) {
         id -> Uuid,
         name -> Text,
@@ -471,27 +492,7 @@ table! {
         slug_id -> Nullable<Uuid>,
         google_ads_conversion_id -> Nullable<Text>,
         google_ads_conversion_labels -> Array<Text>,
-    }
-}
-
-table! {
-    organization_users (id) {
-        id -> Uuid,
-        organization_id -> Uuid,
-        user_id -> Uuid,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
-        role -> Array<Text>,
-    }
-}
-
-table! {
-    organization_venues (id) {
-        id -> Uuid,
-        organization_id -> Uuid,
-        venue_id -> Uuid,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
+        is_allowed_to_refund -> Bool,
     }
 }
 
@@ -538,24 +539,24 @@ table! {
 }
 
 table! {
-    refunded_tickets (id) {
-        id -> Uuid,
-        order_item_id -> Uuid,
-        ticket_instance_id -> Uuid,
-        fee_refunded_at -> Nullable<Timestamp>,
-        ticket_refunded_at -> Nullable<Timestamp>,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
-    }
-}
-
-table! {
     refund_items (id) {
         id -> Uuid,
         refund_id -> Uuid,
         order_item_id -> Uuid,
         quantity -> Int8,
         amount -> Int8,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+table! {
+    refunded_tickets (id) {
+        id -> Uuid,
+        order_item_id -> Uuid,
+        ticket_instance_id -> Uuid,
+        fee_refunded_at -> Nullable<Timestamp>,
+        ticket_refunded_at -> Nullable<Timestamp>,
         created_at -> Timestamp,
         updated_at -> Timestamp,
     }
@@ -756,6 +757,16 @@ table! {
 }
 
 table! {
+    transfer_tickets (id) {
+        id -> Uuid,
+        ticket_instance_id -> Uuid,
+        transfer_id -> Uuid,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+table! {
     transfers (id) {
         id -> Uuid,
         source_user_id -> Uuid,
@@ -769,16 +780,6 @@ table! {
         cancelled_by_user_id -> Nullable<Uuid>,
         direct -> Bool,
         destination_temporary_user_id -> Nullable<Uuid>,
-    }
-}
-
-table! {
-    transfer_tickets (id) {
-        id -> Uuid,
-        ticket_instance_id -> Uuid,
-        transfer_id -> Uuid,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
     }
 }
 
@@ -952,8 +953,8 @@ allow_tables_to_appear_in_same_query!(
     event_genres,
     event_interest,
     event_report_subscribers,
-    events,
     event_users,
+    events,
     external_logins,
     fee_schedule_ranges,
     fee_schedules,
@@ -961,18 +962,18 @@ allow_tables_to_appear_in_same_query!(
     holds,
     notes,
     order_items,
-    orders,
     order_transfers,
+    orders,
     organization_interactions,
     organization_invites,
-    organizations,
     organization_users,
     organization_venues,
+    organizations,
     payment_methods,
     payments,
     push_notification_tokens,
-    refunded_tickets,
     refund_items,
+    refunded_tickets,
     refunds,
     regions,
     settlement_adjustments,
@@ -987,8 +988,8 @@ allow_tables_to_appear_in_same_query!(
     ticket_pricing,
     ticket_type_codes,
     ticket_types,
-    transfers,
     transfer_tickets,
+    transfers,
     user_genres,
     users,
     venues,

--- a/db/src/test/builders/organization_builder.rs
+++ b/db/src/test/builders/organization_builder.rs
@@ -18,6 +18,7 @@ pub struct OrganizationBuilder<'a> {
     additional_fee: i64,
     timezone: Option<String>,
     settlement_type: Option<SettlementTypes>,
+    is_allowed_to_refund: bool,
 }
 
 impl<'a> OrganizationBuilder<'a> {
@@ -36,11 +37,17 @@ impl<'a> OrganizationBuilder<'a> {
             additional_fee: 0,
             timezone: None,
             settlement_type: None,
+            is_allowed_to_refund: false,
         }
     }
 
     pub fn with_member(mut self, user: &User, role: Roles) -> OrganizationBuilder<'a> {
         self.members.insert(user.id.clone(), role);
+        self
+    }
+
+    pub fn is_allowed_to_refund(mut self) -> OrganizationBuilder<'a> {
+        self.is_allowed_to_refund = true;
         self
     }
 
@@ -117,6 +124,7 @@ impl<'a> OrganizationBuilder<'a> {
             cc_fee_percent: self.cc_fee_percent,
             max_additional_fee_in_cents: Some(self.additional_fee),
             timezone: self.timezone,
+            is_allowed_to_refund: Some(self.is_allowed_to_refund),
             ..Default::default()
         };
 

--- a/integration-tests/mocha/test/01 Setup/00 Invites and User Creation/02 Admin - Creates Org.js
+++ b/integration-tests/mocha/test/01 Setup/00 Invites and User Creation/02 Admin - Creates Org.js
@@ -37,7 +37,8 @@ const get = async function (request_body) {
 let requestBody = `{
 "name": "Jazzy_{{$timestamp}}",
 "owner_user_id": "{{admin_id}}",
-"timezone": "America/Los_Angeles"
+"timezone": "America/Los_Angeles",
+"is_allowed_to_refund": true
 }`;
 
 
@@ -66,5 +67,3 @@ describe('02 Admin - Creates Org', function () {
 
 
 });
-
-            


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1158142652422330/1166418437480933

### Description:

This pull request includes logic that fixes the associated asana issue by allowing organizations to have their ability to initiate refunds be toggled by admins and supers.

Adjustments made:
- Create route for organization allows is_allowed_to_refund boolean which when not provided defaults to false
- Update route for organization allows is_allowed_to_refund boolean which when not provided does not update
- Logic that checks applicability to refund an order now checks if the user is an admin or if the organization has is_allowed_to_refund enabled or returns an unauthorized error
- Logic that toggles frontend refund functionality via order details updated to modify refundable flag depending upon if the user is an admin or if the organization is_allowed_to_refund

Note:
- I've defaulted these all to false -- I noticed that we wanted to remove the functionality from across the board via some other discussion so this starts us at that point. We'll need to enable refunds in any environments we want them such as scratches.

### Examples:

As a system administrator I can refund one ticket despite the organization having is_allowed_to_refund set to false:

<img width="1010" alt="Screen Shot 2020-03-16 at 4 22 48 PM" src="https://user-images.githubusercontent.com/1319304/76797617-51080900-67a4-11ea-84a9-29976616ede2.png">

As the organization owner, I can't click the checkbox next to the other ticket as it is disabled by the is_allowed_to_refund flag:

<img width="841" alt="Screen Shot 2020-03-16 at 4 24 15 PM" src="https://user-images.githubusercontent.com/1319304/76797620-52393600-67a4-11ea-99d8-1a6171f9a818.png">

I've temporarily switched the flag in the db to true, this allows me to select the checkbox:

<img width="1008" alt="Screen Shot 2020-03-16 at 4 26 47 PM" src="https://user-images.githubusercontent.com/1319304/76797623-52d1cc80-67a4-11ea-9a20-c3693e9686ad.png">

Now I've set it back to false in the db it fails when it attempts to submit because I lack the permissions (normally you'd be blocked by the disabled checkbox above):

<img width="758" alt="Screen Shot 2020-03-16 at 4 26 59 PM" src="https://user-images.githubusercontent.com/1319304/76797624-52d1cc80-67a4-11ea-84ed-d653f2197e8f.png">

Switching the organization to is_allowed_to_refund = true allows the refund to succeed:

<img width="809" alt="Screen Shot 2020-03-16 at 4 27 08 PM" src="https://user-images.githubusercontent.com/1319304/76797625-536a6300-67a4-11ea-9008-b9c488eb63c9.png">

## Release Details:
### Migrations
 * `migrations/20200316174006_add_is_allowed_to_refund_to_organizations`

### Environment Variables
 * No change
