### PR TITLE
exclude /status endpoint from logs

### DIFF
--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -141,7 +141,7 @@ impl Server {
                                 .max_age(3600)
                                 .finish()
                         })
-                        .wrap(Logger::new(LOGGER_FORMAT))
+                        .wrap(Logger::new(LOGGER_FORMAT).exclude("/status"))
                         .wrap(BigNeonLogger::new())
                         .wrap(DatabaseTransaction::new())
                         .wrap(AppVersionHeader::new())

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -21,7 +21,7 @@ use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
 // Must be valid JSON
-const LOGGER_FORMAT: &'static str = r#"{"level": "INFO", "target":"bigneon::request", "remote_ip":"%a", "user_agent": "%{User-Agent}i", "request": "%r", "status_code": %s, "response_time": %D, "api_version":"%{x-app-version}o", "client_version": "%{X-API-Client-Version}i" }"#;
+const LOGGER_FORMAT: &'static str = r#"{"level": "INFO", "target":"bigneon::request", "remote_ip":"%a", "user_agent": "%{User-Agent}i", "request": "%r", "uri": "%U", "status_code": %s, "response_time": %D, "api_version":"%{x-app-version}o", "client_version": "%{X-API-Client-Version}i" }"#;
 
 pub struct AppState {
     pub clients: Arc<Mutex<HashMap<Uuid, Vec<Addr<EventWebSocket>>>>>,


### PR DESCRIPTION
### References Issues:

### Description:

1. Previously logs for /status endpoint were excluded, though they got introduced as regression with #1710. Status is called quite often and pollutes datadog.

2. For every request usually 2 records are generated. Custom logging middleware generates log record at start and predefined actix middleware logger generates record on successful response. Though there is no way to correlate log records as they using different fields. This PR adds uri field which is present in our custom log middleware, but absent in actix Logger.


## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
