### PR TITLE
Fix profile logic user valid check

### DIFF
--- a/db/src/models/users.rs
+++ b/db/src/models/users.rs
@@ -775,7 +775,7 @@ impl User {
             .to_db_error(ErrorCode::QueryError, "Could not load profile for organization fan")?;
 
         let result = result.remove(0);
-        if result.ticket_sales == 0 && result.tickets_owned == 0 && result.revenue_in_cents == 0 {
+        if !organization.has_fan(&self, conn)? {
             return DatabaseError::no_results("Could not load profile for organization fan, NotFound");
         }
         Ok(FanProfile {

--- a/db/tests/unit/users.rs
+++ b/db/tests/unit/users.rs
@@ -922,23 +922,6 @@ fn get_profile_for_organization() {
         })
     );
 
-    // Add event interest giving access without orders
-    project
-        .create_event_interest()
-        .with_event(&event)
-        .with_user(&user)
-        .finish();
-
-    assert_eq!(
-        user.get_profile_for_organization(&organization, connection),
-        Err(DatabaseError {
-            code: 2000,
-            message: "No results".into(),
-            cause: Some("Could not load profile for organization fan, NotFound".into()),
-            error_code: ErrorCode::NoResults,
-        })
-    );
-
     // Add facebook login
     user.add_external_login(
         None,
@@ -981,6 +964,32 @@ fn get_profile_for_organization() {
             cause: Some("Could not load profile for organization fan, NotFound".into()),
             error_code: ErrorCode::NoResults,
         })
+    );
+
+    // Add event interest giving access without orders
+    project
+        .create_event_interest()
+        .with_event(&event)
+        .with_user(&user)
+        .finish();
+
+    assert_eq!(
+        user.get_profile_for_organization(&organization, connection).unwrap(),
+        FanProfile {
+            first_name: user.first_name.clone(),
+            last_name: user.last_name.clone(),
+            email: user.email.clone(),
+            facebook_linked: true,
+            revenue_in_cents: 0,
+            ticket_sales: 0,
+            tickets_owned: 0,
+            profile_pic_url: user.profile_pic_url.clone(),
+            thumb_profile_pic_url: user.thumb_profile_pic_url.clone(),
+            cover_photo_url: user.cover_photo_url.clone(),
+            created_at: user.created_at,
+            attendance_information: Vec::new(),
+            deleted_at: None
+        }
     );
 
     // Checkout which changes sales data
@@ -1329,13 +1338,22 @@ fn get_profile_for_organization() {
     )
     .unwrap();
     assert_eq!(
-        user4.get_profile_for_organization(&organization, connection),
-        Err(DatabaseError {
-            code: 2000,
-            message: "No results".into(),
-            cause: Some("Could not load profile for organization fan, NotFound".into()),
-            error_code: ErrorCode::NoResults,
-        })
+        user4.get_profile_for_organization(&organization, connection).unwrap(),
+        FanProfile {
+            first_name: user4.first_name.clone(),
+            last_name: user4.last_name.clone(),
+            email: user4.email.clone(),
+            facebook_linked: false,
+            revenue_in_cents: 0,
+            ticket_sales: 0,
+            tickets_owned: 0,
+            profile_pic_url: user4.profile_pic_url.clone(),
+            thumb_profile_pic_url: user4.thumb_profile_pic_url.clone(),
+            cover_photo_url: user4.cover_photo_url.clone(),
+            created_at: user4.created_at,
+            attendance_information: vec![],
+            deleted_at: None
+        }
     );
     assert_eq!(
         user5.get_profile_for_organization(&organization, connection).unwrap(),


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1158142652422330/1165676145234873/f

### Description:
This pull request fixes an issue that we ran into in production around accessing fans. One of the fan profile's appeared to be inaccessible returning not found errors. It appears this occurred because the user in question was fully refunded. The logic was faulty and if the user had no tickets, no sales, and no revenue they instead returned 404. 

This pull request fixes the issue by just relying on the same logic we use for fan search to determine whether the logic should 404 / if the user isn't part of the organization rather than relying on a few random fields like it was previously. 

## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
