### PR TITLE
Conversion cache to non blocking

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -25,7 +25,7 @@ bytes = "0.5"
 chrono = {version = "0.4", features = ["serde"]}
 clap = "2.32"
 customer_io= {path="../customer_io"}
-cache= {path="../cache"}
+cache= { version = "0.2.0", path = "../cache" }
 diesel="1.4.2"
 dotenv = "0.13"
 # Pulling from github as dependency fix merged into master has yet to be released
@@ -41,7 +41,7 @@ logging = {path="../logging"}
 macros = {path="../macros"}
 phonenumber = "0.2.3"
 r2d2 = "0.8"
-redis = "0.13"
+redis = "0.15.1"
 regex = "1"
 reqwest = { version = "0.10.4", features = ["blocking", "json"] }
 serde = "1.0"

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub redis_connection_timeout: u64,
     pub redis_read_timeout: u64,
     pub redis_write_timeout: u64,
+    pub redis_pool_max_size: Option<usize>,
     pub readonly_database_url: String,
     pub redis_cache_period: u64,
     pub client_cache_period: u64,
@@ -153,6 +154,7 @@ const REDIS_CONNECTION_TIMEOUT_MILLI: &str = "REDIS_CONNECTION_TIMEOUT_MILLI";
 const REDIS_READ_TIMEOUT_MILLI: &str = "REDIS_READ_TIMEOUT_MILLI";
 const REDIS_WRITE_TIMEOUT_MILLI: &str = "REDIS_WRITE_TIMEOUT_MILLI";
 const REDIS_CACHE_PERIOD_MILLI: &str = "REDIS_CACHE_PERIOD_MILLI";
+const REDIS_POOL_MAX_SIZE: &str = "REDIS_POOL_MAX_SIZE";
 const CLIENT_CACHE_PERIOD: &str = "CLIENT_CACHE_PERIOD";
 const READONLY_DATABASE_URL: &str = "READONLY_DATABASE_URL";
 const DOMAIN: &str = "DOMAIN";
@@ -274,6 +276,9 @@ impl Config {
                     .expect("Not a valid value for redis cache period in milliseconds")
             })
             .unwrap_or(10000);
+        let redis_pool_max_size = env::var(&REDIS_POOL_MAX_SIZE)
+            .ok()
+            .map(|s| s.parse().expect("Not a valid value for maximum size of redis pool"));
         let client_cache_period = env::var(&CLIENT_CACHE_PERIOD)
             .ok()
             .map(|s| s.parse().expect("Not a valid value for client cache period in seconds"))
@@ -456,6 +461,7 @@ impl Config {
             redis_read_timeout,
             redis_write_timeout,
             redis_cache_period,
+            redis_pool_max_size,
             client_cache_period,
             readonly_database_url,
             domain,

--- a/api/src/database/database.rs
+++ b/api/src/database/database.rs
@@ -71,6 +71,7 @@ pub fn load_redis_connection(config: &Config) -> Option<RedisCacheConnection> {
             config.redis_connection_timeout,
             config.redis_read_timeout,
             config.redis_write_timeout,
+            config.redis_pool_max_size,
         )
         .expect("Redis failed to create connection pool")
     })

--- a/api/src/helpers/caching.rs
+++ b/api/src/helpers/caching.rs
@@ -3,6 +3,7 @@ use crate::database::CacheDatabase;
 use crate::errors::*;
 use crate::helpers::*;
 use crate::utils::redis::*;
+use cache::CacheConnection;
 use actix_web::HttpResponse;
 use serde::Serialize;
 use serde_json::{self, Value};

--- a/api/src/helpers/caching.rs
+++ b/api/src/helpers/caching.rs
@@ -1,67 +1,89 @@
 use crate::config::Config;
+use crate::database::CacheDatabase;
 use crate::errors::*;
 use crate::helpers::*;
 use crate::utils::redis::*;
 use actix_web::HttpResponse;
-use cache::CacheConnection;
 use serde::Serialize;
 use serde_json::{self, Value};
 use std::borrow::Borrow;
 
-pub(crate) fn set_cached_value<T: Serialize>(
-    mut cache_connection: impl CacheConnection,
+pub(crate) async fn set_cached_value<T: Serialize>(
+    cache_db: &CacheDatabase,
     config: &Config,
     http_response: &HttpResponse,
     query: &T,
 ) -> Result<(), ApiError> {
+    if cache_db.inner.is_none() {
+        return Ok(());
+    }
+    let mut cache_connection = cache_db.inner.clone().unwrap();
+
     let body = application::unwrap_body_to_string(http_response).map_err(|e| ApplicationError::new(e.to_string()))?;
     let cache_period = config.redis_cache_period;
     let query_serialized = serde_json::to_string(query)?;
-    if let Err(err) = cache_connection.add(query_serialized.borrow(), body, Some(cache_period as usize)) {
+    if let Err(err) = cache_connection
+        .add(query_serialized.borrow(), body, Some(cache_period as usize))
+        .await
+    {
         error!("helpers::caching#set_cached_value: {:?}", err);
     }
     Ok(())
 }
 
-pub(crate) fn get_cached_value<T: Serialize>(
-    mut cache_connection: impl CacheConnection,
-    config: &Config,
+pub(crate) async fn get_cached_value<T: Serialize>(
+    cache_db: &CacheDatabase,
+    _config: &Config,
     query: T,
 ) -> Option<HttpResponse> {
+    if cache_db.inner.is_none() {
+        return None;
+    }
+    let mut cache_connection = cache_db.inner.clone().unwrap();
+
     let query_serialized = serde_json::to_string(&query).ok()?;
-    if config.redis_connection_string.is_some() {
-        match cache_connection.get(&query_serialized) {
-            Ok(cached_value) => {
-                if let Some(value) = cached_value {
-                    let payload: Value = serde_json::from_str(&value).ok()?;
-                    return Some(HttpResponse::Ok().json(&payload));
-                }
+
+    match cache_connection.get(&query_serialized).await {
+        Ok(cached_value) => {
+            if let Some(value) = cached_value {
+                let payload: Value = serde_json::from_str(&value).ok()?;
+                return Some(HttpResponse::Ok().json(&payload));
             }
-            Err(err) => {
-                error!("helpers::caching#get_cached_value: {:?}", err);
-                return None;
-            }
+        }
+        Err(err) => {
+            error!("helpers::caching#get_cached_value: {:?}", err);
+            return None;
         }
     }
     None
 }
 
-pub(crate) fn delete_by_key_fragment(
-    mut cache_connection: impl CacheConnection,
-    key_fragment: String,
-) -> Result<(), ApiError> {
-    if let Err(err) = cache_connection.delete_by_key_fragment(&key_fragment) {
+pub(crate) async fn delete_by_key_fragment(cache_db: &CacheDatabase, key_fragment: String) -> Result<(), ApiError> {
+    if cache_db.inner.is_none() {
+        return Ok(());
+    }
+    let mut cache_connection = cache_db.inner.clone().unwrap();
+
+    if let Err(err) = cache_connection.delete_by_key_fragment(&key_fragment).await {
         error!("helpers::caching#delete_by_key_fragment: {:?}", err);
     }
     Ok(())
 }
 
-pub(crate) fn publish<T: Serialize>(
-    mut cache_connection: impl CacheConnection,
+pub(crate) async fn publish<T: Serialize>(
+    cache_db: &CacheDatabase,
     redis_pubsub_channel: RedisPubSubChannel,
     message: T,
 ) -> Result<(), ApiError> {
-    if let Err(err) = cache_connection.publish(&redis_pubsub_channel.to_string(), &serde_json::to_string(&message)?) {
+    if cache_db.inner.is_none() {
+        return Ok(());
+    }
+    let mut cache_connection = cache_db.inner.clone().unwrap();
+
+    if let Err(err) = cache_connection
+        .publish(&redis_pubsub_channel.to_string(), &serde_json::to_string(&message)?)
+        .await
+    {
         error!("helpers::caching#publish: {:?}", err);
     }
     Ok(())

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -107,8 +107,7 @@ impl Server {
 
             let clients = Arc::new(Mutex::new(HashMap::new()));
 
-            let mut redis_pubsub_processor =
-                RedisPubSubProcessor::new(config.clone(), database.clone(), clients.clone());
+            let mut redis_pubsub_processor = RedisPubSubProcessor::new(config.clone(), clients.clone());
             if process_redis_pubsub {
                 redis_pubsub_processor.start();
             }

--- a/api/src/utils/redis/redis_pubsub_processor.rs
+++ b/api/src/utils/redis/redis_pubsub_processor.rs
@@ -10,7 +10,6 @@ use std::time::Duration;
 use log::Level::*;
 
 use crate::config::Config;
-use crate::database::*;
 use crate::errors::*;
 use crate::models::*;
 use crate::utils::redis::*;
@@ -20,7 +19,7 @@ use uuid::Uuid;
 
 pub struct RedisPubSubProcessor {
     config: Config,
-    database: Database,
+    client: Option<redis::Client>,
     worker_threads: Vec<(Sender<()>, JoinHandle<Result<(), ApiError>>)>,
     websocket_clients: Arc<Mutex<HashMap<Uuid, Vec<Addr<EventWebSocket>>>>>,
 }
@@ -28,12 +27,15 @@ pub struct RedisPubSubProcessor {
 impl RedisPubSubProcessor {
     pub fn new(
         config: Config,
-        database: Database,
         websocket_clients: Arc<Mutex<HashMap<Uuid, Vec<Addr<EventWebSocket>>>>>,
     ) -> RedisPubSubProcessor {
+        let client = config
+            .redis_connection_string
+            .clone()
+            .map(|url| redis::Client::open(url).unwrap());
         RedisPubSubProcessor {
             config,
-            database,
+            client,
             websocket_clients,
             worker_threads: vec![],
         }
@@ -41,58 +43,50 @@ impl RedisPubSubProcessor {
 
     pub fn run_process(
         config: Config,
-        database: Database,
+        mut conn: redis::Connection,
         websocket_clients: Arc<Mutex<HashMap<Uuid, Vec<Addr<EventWebSocket>>>>>,
         rx: Receiver<()>,
     ) -> Result<(), ApiError> {
-        if let Some(mut connection) = database
-            .cache_database
-            .clone()
-            .inner
-            .clone()
-            .and_then(|conn| conn.conn().ok())
-        {
-            let mut pubsub = connection.as_pubsub();
-            pubsub.set_read_timeout(Some(Duration::from_millis(config.redis_read_timeout)))?;
+        let mut pubsub = conn.as_pubsub();
+        pubsub.set_read_timeout(Some(Duration::from_millis(config.redis_read_timeout)))?;
 
-            // Todo: switch channels into enum
-            pubsub.subscribe(RedisPubSubChannel::TicketRedemptions.to_string())?;
+        // Todo: switch channels into enum
+        pubsub.subscribe(RedisPubSubChannel::TicketRedemptions.to_string())?;
 
-            loop {
-                if rx.try_recv().is_ok() {
-                    jlog!(
-                        Info,
-                        "bigneon::redis_pubsub_processor",
-                        "Stopping Redis PubSub processor",
-                        {}
-                    );
-                    break;
-                }
+        loop {
+            if rx.try_recv().is_ok() {
+                jlog!(
+                    Info,
+                    "bigneon::redis_pubsub_processor",
+                    "Stopping Redis PubSub processor",
+                    {}
+                );
+                break;
+            }
 
-                match pubsub.get_message() {
-                    Ok(message) => match message.get_channel_name() {
-                        "TicketRedemptions" => {
-                            let payload: messages::TicketRedemption =
-                                serde_json::from_str(&message.get_payload::<String>()?)?;
-                            let clients = websocket_clients.clone();
-                            let clients_mutex = clients.lock().unwrap();
+            match pubsub.get_message() {
+                Ok(message) => match message.get_channel_name() {
+                    "TicketRedemptions" => {
+                        let payload: messages::TicketRedemption =
+                            serde_json::from_str(&message.get_payload::<String>()?)?;
+                        let clients = websocket_clients.clone();
+                        let clients_mutex = clients.lock().unwrap();
 
-                            if let Some(listeners) = clients_mutex.get(&payload.event_id) {
-                                EventWebSocket::send_message(
-                                    &listeners,
-                                    EventWebSocketMessage::new(json!({
-                                            "event_id": payload.event_id,
-                                            "ticket_id": payload.ticket_id,
-                                            "event_web_socket_type": EventWebSocketType::TicketRedemption
-                                    })),
-                                );
-                            }
+                        if let Some(listeners) = clients_mutex.get(&payload.event_id) {
+                            EventWebSocket::send_message(
+                                &listeners,
+                                EventWebSocketMessage::new(json!({
+                                        "event_id": payload.event_id,
+                                        "ticket_id": payload.ticket_id,
+                                        "event_web_socket_type": EventWebSocketType::TicketRedemption
+                                })),
+                            );
                         }
-                        _ => (),
-                    },
-                    Err(_) => {
-                        thread::sleep(Duration::from_secs(1));
                     }
+                    _ => (),
+                },
+                Err(_) => {
+                    thread::sleep(Duration::from_secs(1));
                 }
             }
         }
@@ -109,13 +103,13 @@ impl RedisPubSubProcessor {
             {}
         );
 
-        let database = self.database.clone();
+        let connection = self.client.as_ref().unwrap().get_connection().unwrap();
         let config = self.config.clone();
         let websocket_clients = self.websocket_clients.clone();
         self.worker_threads.push((
             redis_pubsub_tx,
             thread::spawn(move || {
-                let result = RedisPubSubProcessor::run_process(config, database, websocket_clients, redis_pubsub_rx)
+                let result = RedisPubSubProcessor::run_process(config, connection, websocket_clients, redis_pubsub_rx)
                     .map_err(|e| {
                         jlog!(
                             Error,

--- a/cache/Cargo.toml
+++ b/cache/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "cache"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["toiletspider <dan4rie@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-redis = "0.13"
-r2d2_redis = "0.12.0"
+redis = "0.15"
+deadpool-redis = "0.5"
+deadpool = "0.5"
 chrono = {version = "0.4", features = ["serde"]}
+async-trait = "0.1"
+tokio = { version = "0.2", features = ["macros", "rt-core", "time"] }

--- a/cache/src/cache_error.rs
+++ b/cache/src/cache_error.rs
@@ -1,5 +1,5 @@
-use redis::RedisError;
 use deadpool::managed::PoolError;
+use redis::RedisError;
 use std::error::Error;
 use std::fmt;
 use tokio::time::Elapsed;

--- a/cache/src/cache_error.rs
+++ b/cache/src/cache_error.rs
@@ -1,7 +1,8 @@
-use crate::r2d2_redis::r2d2::Error as R2D2Error;
-use crate::redis::RedisError;
+use redis::RedisError;
+use deadpool::managed::PoolError;
 use std::error::Error;
 use std::fmt;
+use tokio::time::Elapsed;
 
 #[derive(Debug)]
 pub struct CacheError {
@@ -26,14 +27,20 @@ impl fmt::Display for CacheError {
     }
 }
 
-impl From<R2D2Error> for CacheError {
-    fn from(e: R2D2Error) -> Self {
+impl From<PoolError<RedisError>> for CacheError {
+    fn from(e: PoolError<RedisError>) -> Self {
         CacheError::new(e.to_string())
     }
 }
 
 impl From<RedisError> for CacheError {
     fn from(e: RedisError) -> Self {
+        CacheError::new(e.to_string())
+    }
+}
+
+impl From<Elapsed> for CacheError {
+    fn from(e: Elapsed) -> Self {
         CacheError::new(e.to_string())
     }
 }

--- a/cache/src/lib.rs
+++ b/cache/src/lib.rs
@@ -1,7 +1,3 @@
-extern crate chrono;
-extern crate r2d2_redis;
-extern crate redis;
-
 pub use self::cache_error::*;
 pub use self::redis_cache_connection::*;
 

--- a/cache/src/redis_cache_connection.rs
+++ b/cache/src/redis_cache_connection.rs
@@ -1,7 +1,6 @@
 use crate::cache_error::*;
 use deadpool_redis::{Pool, Config, ConnectionWrapper};
 use deadpool::managed::{PoolConfig, Timeouts, Object};
-use std::sync::Arc;
 use std::time::Duration;
 use async_trait::async_trait;
 use redis::{RedisError, AsyncCommands};
@@ -22,7 +21,7 @@ pub trait CacheConnection {
 // Implementation
 #[derive(Clone)]
 pub struct RedisCacheConnection {
-    pool: Arc<Pool>,
+    pool: Pool,
     read_timeout: Duration,
     write_timeout: Duration,
 }
@@ -49,7 +48,7 @@ impl RedisCacheConnection {
         let pool = pool_config.create_pool()?;
 
         Ok(RedisCacheConnection {
-            pool: Arc::from(pool),
+            pool,
             read_timeout: Duration::from_millis(read_timeout),
             write_timeout: Duration::from_millis(write_timeout),
         })

--- a/cache/src/redis_cache_connection.rs
+++ b/cache/src/redis_cache_connection.rs
@@ -73,10 +73,11 @@ impl RedisCacheConnection {
     }
 }
 
+//#[async_trait]
 impl RedisCacheConnection {
     pub async fn get(&mut self, key: &str) -> Result<Option<String>, CacheError> {
         let mut conn = self.conn().await?;
-        Ok(timeout(self.read_timeout, conn.get(key)).await??)
+        Ok(conn.get(key).await?)
     }
 
     pub async fn publish(&mut self, channel: &str, message: &str) -> Result<(), CacheError> {

--- a/cache/src/redis_cache_connection.rs
+++ b/cache/src/redis_cache_connection.rs
@@ -26,6 +26,16 @@ pub struct RedisCacheConnection {
     write_timeout: Duration,
 }
 
+impl std::fmt::Debug for RedisCacheConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RedisCacheConnection")
+            .field("read_timeout", &self.read_timeout)
+            .field("write_timeout", &self.write_timeout)
+            .field("pool", &self.pool.status())
+            .finish()
+    }
+}
+
 impl RedisCacheConnection {
     pub fn create_connection_pool(
         database_url: &str,


### PR DESCRIPTION
### References Issues:

https://app.asana.com/0/1166776801311684/1167450377419251

### Description:

Currently all requests to `/events/*` are going through cache and cache implementation is blocking for now. Based on load test benchmarks some requests take 50-100ms which is a long time to sit in a blocked state. Potentially there should be benefit of converting cache to async as to require less actix workers to process same amount of requests. Not likely there will be response time benefit, but also possible.

Cache should be fairly easy to convert to async as there are only few operations need to be supported. 

## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
