### PR TITLE
Upgrade to rust 1 42 to get better report on server worker failures

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,7 +59,7 @@ steps:
     -   name: rust-fmt-check
         depends_on:
             - clone
-        image: rust:1.41.1
+        image: rust:1.42
         commands:
             - rustup component add rustfmt
             - cargo fmt --all -- --check
@@ -88,7 +88,7 @@ steps:
     -   name: compile
         depends_on:
             - clone
-        image: rust:1.41.1
+        image: rust:1.42
         environment:
             <<: *env
             GH_USER_EMAIL: 'travis@travis-ci.org'
@@ -152,7 +152,7 @@ steps:
     -   name: other-tests
         depends_on:
             - compile
-        image: rust:1.41.1
+        image: rust:1.42
         environment:
             <<: *env
             DATABASE_URL: postgres://app:password@database/other_tests

--- a/.drone.yml
+++ b/.drone.yml
@@ -317,6 +317,6 @@ services:
 
 ---
 kind: signature
-hmac: ab821eedf8160cb233427bce04f702fd594a430bd21cb411f6bd40bd3af5c17a
+hmac: 46c921cacffcd650bb22424af0d71701b0f33034b3846f89abe48d654628181f
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.41.1 as builder
+FROM rust:1.42 as builder
 
 RUN \
     wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_0-stable.zip && \

--- a/api/src/controllers/holds.rs
+++ b/api/src/controllers/holds.rs
@@ -14,7 +14,6 @@ use chrono::prelude::*;
 use db::models::*;
 use log::Level::Warn;
 use serde_with::rust::double_option;
-use std::error::Error;
 use uuid::Uuid;
 
 #[derive(Deserialize, Serialize)]
@@ -202,7 +201,7 @@ pub async fn link(
         Ok(l) => l,
         Err(e) => {
             jlog!(Warn, "Error when creating an aliased link",
-            {"error": e.description(), "raw_url": &raw_url, "alias": hold.redemption_code.as_ref().unwrap()});
+            {"error": e.to_string(), "raw_url": &raw_url, "alias": hold.redemption_code.as_ref().unwrap()});
             // Alias might not be unique, create without
             linker.create_deep_link_with_fallback(&raw_url)
         }

--- a/api/src/errors/api_error.rs
+++ b/api/src/errors/api_error.rs
@@ -66,6 +66,7 @@ impl fmt::Display for ApiError {
 }
 
 impl Error for ApiError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         self.0.description()
     }

--- a/api/src/middleware/database_transaction.rs
+++ b/api/src/middleware/database_transaction.rs
@@ -7,7 +7,6 @@ use actix_web::{FromRequest, HttpRequest};
 use diesel::connection::TransactionManager;
 use diesel::Connection as DieselConnection;
 use futures::future::{ok, Ready};
-use std::error::Error;
 
 pub trait RequestConnection {
     fn connection(&self) -> Result<Connection, ApiError>;
@@ -45,7 +44,7 @@ impl DatabaseTransaction {
             match transaction_response {
                 Ok(_) => Ok(()),
                 Err(e) => {
-                    error!("Diesel Error: {}", e.description());
+                    error!("Diesel Error: {}", e.to_string());
                     let error: ApiError = e.into();
                     Err(error)
                 }

--- a/api/src/payments/payment_processor_error.rs
+++ b/api/src/payments/payment_processor_error.rs
@@ -20,7 +20,7 @@ impl Error for PaymentProcessorError {
 impl fmt::Display for PaymentProcessorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match &self.cause {
-            Some(c) => write!(f, "{} caused by: {}", self.description, c.description()),
+            Some(c) => write!(f, "{} caused by: {}", self.description, c.to_string()),
             None => write!(f, "{}", self.description),
         }
     }

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -16,7 +16,6 @@ use actix_web::{web, web::Data, App, HttpServer};
 use db::utils::errors::DatabaseError;
 use log::Level::{Debug, Warn};
 use std::collections::HashMap;
-use std::error::Error;
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
@@ -172,7 +171,7 @@ impl Server {
 
             match exit {
                 Ok(_) => {}
-                Err(e) => jlog!(Warn, "api::server", "Server exit with error", {"error": e.description()}),
+                Err(e) => jlog!(Warn, "api::server", "Server exit with error", {"error": e.to_string()}),
             };
 
             if process_actions || process_events {

--- a/api/tests/support/database.rs
+++ b/api/tests/support/database.rs
@@ -5,7 +5,6 @@ use db::prelude::*;
 
 use diesel::Connection;
 use diesel::PgConnection;
-use std::error::Error;
 use uuid::Uuid;
 
 #[derive(Clone)]
@@ -22,7 +21,7 @@ impl TestDatabase {
             panic!(
                 "Connection to {} could not be established:{}",
                 config.database_url,
-                e.description()
+                e.to_string()
             )
         });
 

--- a/db/src/bin.rs
+++ b/db/src/bin.rs
@@ -26,7 +26,6 @@ use clap::{App, Arg, SubCommand};
 use diesel::connection::SimpleConnection;
 use diesel::pg::PgConnection;
 use diesel::Connection;
-use std::error::Error;
 use std::fs::{create_dir_all, File};
 use std::io::Write;
 use std::path::Path;
@@ -260,7 +259,7 @@ fn rollback_db(matches: &ArgMatches) {
 
     match diesel_migrations::revert_latest_migration(&connection) {
         Ok(s) => std::io::stdout().write(s.as_bytes()),
-        Err(e) => std::io::stderr().write(e.description().as_bytes()),
+        Err(e) => std::io::stderr().write(e.to_string().as_bytes()),
     }
     .expect("Rollback failed");
 }

--- a/db/src/models/communication.rs
+++ b/db/src/models/communication.rs
@@ -28,7 +28,7 @@ impl CommAddress {
     }
 
     pub fn get(&self) -> Vec<String> {
-        (self.addresses.clone())
+        self.addresses.clone()
     }
 
     pub fn get_first(&self) -> Result<String, DatabaseError> {

--- a/db/src/models/wallets.rs
+++ b/db/src/models/wallets.rs
@@ -47,7 +47,7 @@ impl Wallet {
             };
         }
 
-        (NewWallet {
+        NewWallet {
             user_id: Some(user_id),
             name,
             secret_key: convert_bytes_to_hexstring(&secret_key),
@@ -55,7 +55,7 @@ impl Wallet {
             default_flag,
             ..Default::default()
         }
-        .commit(conn))
+        .commit(conn)
     }
 
     pub fn create_for_organization(
@@ -71,7 +71,7 @@ impl Wallet {
         } else {
             default_flag = false;
         };
-        (NewWallet {
+        NewWallet {
             organization_id: Some(organization_id),
             name,
             secret_key: convert_bytes_to_hexstring(&secret_key),
@@ -79,7 +79,7 @@ impl Wallet {
             default_flag,
             ..Default::default()
         }
-        .commit(conn))
+        .commit(conn)
     }
 
     pub fn find_for_user(user_id: Uuid, conn: &PgConnection) -> Result<Vec<Wallet>, DatabaseError> {

--- a/db/src/utils/errors.rs
+++ b/db/src/utils/errors.rs
@@ -414,7 +414,7 @@ impl<T> SingleResult<T> for Result<Vec<T>, DatabaseError> {
 #[test]
 fn error_with_unknown_code() {
     let err = DatabaseError::new(ErrorCode::Unknown, None);
-    assert_eq!(err.to_string(), err.message);
+    assert_eq!(err.message, "Unknown database error");
     assert_eq!(err.code, 10);
     assert!(err.cause.is_none());
     assert_eq!(format!("{}", err), "[10] Unknown database error");
@@ -423,7 +423,7 @@ fn error_with_unknown_code() {
 #[test]
 fn error_with_known_code() {
     let err = DatabaseError::new(ErrorCode::InvalidInput, None);
-    assert_eq!(err.to_string(), "Invalid input");
+    assert_eq!(err.message, "Invalid input");
     assert_eq!(err.code, 1000);
     assert!(err.cause.is_none());
     assert_eq!(format!("{}", err), "[1000] Invalid input");
@@ -432,8 +432,8 @@ fn error_with_known_code() {
 #[test]
 fn unknown_error_with_cause() {
     let cause = DatabaseError::new(ErrorCode::Unknown, None);
-    let err = DatabaseError::new(ErrorCode::InvalidInput, Some(cause.to_string()));
-    assert_eq!(err.to_string(), "Invalid input");
+    let err = DatabaseError::new(ErrorCode::InvalidInput, Some(cause.message));
+    assert_eq!(err.message, "Invalid input");
     assert_eq!(err.code, 1000);
     assert!(err.cause.is_some());
     assert_eq!(

--- a/db/src/utils/errors.rs
+++ b/db/src/utils/errors.rs
@@ -125,7 +125,7 @@ impl From<jsonwebtoken::errors::Error> for DatabaseError {
     fn from(s: jsonwebtoken::errors::Error) -> DatabaseError {
         DatabaseError::new(
             ErrorCode::InternalError,
-            Some(format!("JSON Web Token error: {}", s.description())),
+            Some(format!("JSON Web Token error: {}", s.to_string())),
         )
     }
 }
@@ -414,7 +414,7 @@ impl<T> SingleResult<T> for Result<Vec<T>, DatabaseError> {
 #[test]
 fn error_with_unknown_code() {
     let err = DatabaseError::new(ErrorCode::Unknown, None);
-    assert_eq!(err.description(), err.message);
+    assert_eq!(err.to_string(), err.message);
     assert_eq!(err.code, 10);
     assert!(err.cause.is_none());
     assert_eq!(format!("{}", err), "[10] Unknown database error");
@@ -423,7 +423,7 @@ fn error_with_unknown_code() {
 #[test]
 fn error_with_known_code() {
     let err = DatabaseError::new(ErrorCode::InvalidInput, None);
-    assert_eq!(err.description(), "Invalid input");
+    assert_eq!(err.to_string(), "Invalid input");
     assert_eq!(err.code, 1000);
     assert!(err.cause.is_none());
     assert_eq!(format!("{}", err), "[1000] Invalid input");
@@ -432,8 +432,8 @@ fn error_with_known_code() {
 #[test]
 fn unknown_error_with_cause() {
     let cause = DatabaseError::new(ErrorCode::Unknown, None);
-    let err = DatabaseError::new(ErrorCode::InvalidInput, Some(cause.description().to_string()));
-    assert_eq!(err.description(), "Invalid input");
+    let err = DatabaseError::new(ErrorCode::InvalidInput, Some(cause.to_string()));
+    assert_eq!(err.to_string(), "Invalid input");
     assert_eq!(err.code, 1000);
     assert!(err.cause.is_some());
     assert_eq!(

--- a/db/src/utils/passwords.rs
+++ b/db/src/utils/passwords.rs
@@ -2,7 +2,6 @@ use argon2rs::verifier::Encoded;
 use rand;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
-use std::error::Error;
 use std::str;
 use utils::errors::{DatabaseError, ErrorCode};
 
@@ -26,7 +25,7 @@ impl PasswordHash {
             Ok(hash) => Ok(PasswordHash { hash }),
             Err(e) => Err(DatabaseError::new(
                 ErrorCode::InvalidInput,
-                Some(e.description().to_string()),
+                Some(e.to_string()),
             )),
         }
     }

--- a/db/src/utils/passwords.rs
+++ b/db/src/utils/passwords.rs
@@ -23,10 +23,7 @@ impl PasswordHash {
     pub fn from_str(hash_str: &str) -> Result<PasswordHash, DatabaseError> {
         match Encoded::from_u8(hash_str.as_bytes()) {
             Ok(hash) => Ok(PasswordHash { hash }),
-            Err(e) => Err(DatabaseError::new(
-                ErrorCode::InvalidInput,
-                Some(e.to_string()),
-            )),
+            Err(e) => Err(DatabaseError::new(ErrorCode::InvalidInput, Some(e.to_string()))),
         }
     }
 

--- a/globee/src/lib.rs
+++ b/globee/src/lib.rs
@@ -329,13 +329,13 @@ pub struct Errors(Vec<ValidationError>);
 
 impl StdError for Errors {
     fn description(&self) -> &str {
-        "One or more errors occurred"
+        "One or more globee errors occured"
     }
 }
 
 impl fmt::Display for Errors {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_string())
+        write!(f, "{:?}", self)
     }
 }
 


### PR DESCRIPTION
### References Issues:

https://app.asana.com/0/1166776801311684/1168613835961673

### Description:

If any of workers failing we get error like below:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "SendError(..)"', src/libcore/result.rs:1188:5
```

Rust 1.42 comes with improvement to display a source code line of where panic was triggered. This would improve maintenance.


## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
