### PR TITLE
Adjust events index cache strategy

### DIFF
--- a/api/src/routing.rs
+++ b/api/src/routing.rs
@@ -79,7 +79,7 @@ pub fn routes(app: &mut web::ServiceConfig) {
     .service(
         web::resource("/events")
         // In future it may be better to cache this for every user to save the database hit
-        .wrap(CacheResource::new(CacheUsersBy::GlobalRoles))
+        .wrap(CacheResource::new(CacheUsersBy::PublicUsersOnly))
         .route(web::get().to(events::index))
         .route(web::post().to(events::create)),
     )


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1158142652422330/1163611145279329

### Description:
Changes the routing to use the public users only strategy for the events index. We switched our cache strategy to use global roles but organization members can see draft events and future published events so it could cache their events list retrieved otherwise for non members leading to the events index showing drafts in that state. 

I tested guest, logged in users, and logged in org member users and confirmed the former two cache with a key along the lines of `"{\"method\":\"GET\",\"page\":\"0\",\"path\":\"/events\",\"query\":\"\",\"status\":\"Published\"}"` while the logged in org members do not receive a cached reply as intended.

## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
