### PR TITLE
Bubble down revoked scopes

### DIFF
--- a/db/src/models/organization_invites.rs
+++ b/db/src/models/organization_invites.rs
@@ -125,7 +125,7 @@ impl OrganizationInvite {
 
     pub fn create(
         org_id: Uuid,
-        invitee_id: Uuid,
+        inviter_id: Uuid,
         email: &str,
         user_id: Option<Uuid>,
         roles: Vec<Roles>,
@@ -133,7 +133,7 @@ impl OrganizationInvite {
     ) -> NewOrganizationInvite {
         NewOrganizationInvite {
             organization_id: org_id,
-            inviter_id: invitee_id,
+            inviter_id,
             user_email: email.into(),
             security_token: None,
             user_id,


### PR DESCRIPTION
### Description:
If a user has revoked scopes, they should not be able to create a new user that does not have those revoked scopes. 
Case in point is removing ability to cancel events, if they created a new user of the same level, that user _would_ be able to cancel events. This PR copies all revoked scopes to new invited users.
## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
