### PR TITLE
Fix purchased ticket count logic

### DIFF
--- a/api/src/controllers/redemption_codes.rs
+++ b/api/src/controllers/redemption_codes.rs
@@ -31,7 +31,7 @@ pub enum RedemptionCodeResponse {
         ticket_types: Vec<UserDisplayTicketType>,
         redemption_code: String,
         max_uses: i64,
-        available: i64,
+        available: Option<i64>,
         discount_in_cents: Option<i64>,
         discount_as_percentage: Option<i64>,
         code_type: CodeTypes,

--- a/api/tests/functional/redemption_codes.rs
+++ b/api/tests/functional/redemption_codes.rs
@@ -257,7 +257,7 @@ async fn show_code() {
             assert_eq!(end_date, code.end_date);
             assert_eq!(discount_in_cents, code.discount_in_cents);
             assert_eq!(code_type, CodeTypes::Discount);
-            assert_eq!(available, 30);
+            assert_eq!(available, Some(30));
             assert_eq!(discount_as_percentage, None);
             assert_eq!(user_purchased_ticket_count, None);
         }

--- a/db/src/models/codes.rs
+++ b/db/src/models/codes.rs
@@ -34,7 +34,7 @@ pub struct Code {
 pub struct CodeAvailability {
     #[serde(flatten)]
     pub code: Code,
-    pub available: i64,
+    pub available: Option<i64>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, QueryableByName, Serialize)]
@@ -75,7 +75,7 @@ pub struct DisplayCode {
 pub struct DisplayCodeAvailability {
     #[serde(flatten)]
     pub display_code: DisplayCode,
-    pub available: i64,
+    pub available: Option<i64>,
 }
 
 #[derive(AsChangeset, Debug, Default, Deserialize, Validate)]
@@ -102,6 +102,7 @@ impl Code {
                     .or(orders::on_behalf_of_user_id.is_null().and(orders::user_id.eq(user.id))),
             )
             .filter(orders::status.eq(OrderStatus::Paid))
+            .filter(codes::id.eq(self.id))
             .select(sql::<BigInt>("CAST(COALESCE(SUM(order_items.quantity), 0) AS BIGINT)"))
             .first(conn)
             .to_db_error(
@@ -133,8 +134,21 @@ impl Code {
         Ok(CodeAvailability { code, available })
     }
 
-    pub fn available(&self, conn: &PgConnection) -> Result<i64, DatabaseError> {
-        Ok(self.max_uses - Code::find_number_of_uses(self.id, None, conn)?)
+    pub fn available(&self, conn: &PgConnection) -> Result<Option<i64>, DatabaseError> {
+        Code::availablity_by_code_id_max_uses(self.id, self.max_uses, conn)
+    }
+
+    // TODO: retire this method in the future after we make max_uses an optional field and refactor the logic to removex 0 == infinite behavior
+    fn availablity_by_code_id_max_uses(
+        id: Uuid,
+        max_uses: i64,
+        conn: &PgConnection,
+    ) -> Result<Option<i64>, DatabaseError> {
+        if max_uses == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(max_uses - Code::find_number_of_uses(id, None, conn)?))
+        }
     }
 
     pub fn find_number_of_uses(
@@ -219,8 +233,7 @@ impl Code {
             deleted_at: None,
         };
 
-        let available = display_code.max_uses - Code::find_number_of_uses(display_code.id, None, conn)?;
-
+        let available = self.available(conn)?;
         Ok(DisplayCodeAvailability {
             display_code,
             available,
@@ -323,7 +336,7 @@ impl Code {
         let mut display_codes_availability = Vec::new();
 
         for dc in display_codes {
-            let available = dc.max_uses - Code::find_number_of_uses(dc.id, None, conn)?;
+            let available = Code::availablity_by_code_id_max_uses(dc.id, dc.max_uses, conn)?;
             display_codes_availability.push(DisplayCodeAvailability {
                 display_code: dc,
                 available,

--- a/db/src/models/holds.rs
+++ b/db/src/models/holds.rs
@@ -212,6 +212,7 @@ impl Hold {
                     .eq(user.id)
                     .or(orders::on_behalf_of_user_id.is_null().and(orders::user_id.eq(user.id))),
             )
+            .filter(holds::id.eq(self.id))
             .filter(orders::status.eq(OrderStatus::Paid))
             .select(sql::<BigInt>("CAST(COALESCE(SUM(order_items.quantity), 0) AS BIGINT)"))
             .first(conn)

--- a/db/src/models/orders.rs
+++ b/db/src/models/orders.rs
@@ -328,10 +328,10 @@ impl Order {
                 let mut available = available_quantity as i64;
                 if let Some(code_id) = item.code_id {
                     let code = Code::find(code_id, conn)?;
-                    let code_available = code.available(conn)? as i64;
-
-                    if code_available < available {
-                        available = code_available;
+                    if let Some(code_available) = code.available(conn)? {
+                        if code_available < available {
+                            available = code_available;
+                        }
                     }
                 } else if let Some(hold_id) = item.hold_id {
                     let hold = Hold::find(hold_id, conn)?;


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1158142652422330/1163466546088745

### Description:
I left some notes in the associated asana issue but this primarily fixes the following:
- Code availability allowed for unlimited uses by using the number "0" versus a nullable field but the logic to surface how many tickets were available didn't take the infinite number into account (an older pre-existing bug for those unlimited codes)
- The logic on the API side to provide the frontend with the number of ticket purchases by user for the code ended up not properly filtering to the specific code itself. This was an oversight from the original PR for adding this ahead of the frontend work (not currently used but will be soon). I've augmented the tests to account for that case.

At first I wondered if it was worth moving availability data into its own endpoint (as a follow up tech debt card) to allow for caching but thinking it over:
- Caching an endpoint that's quick and rarely called seems like an over optimization
- The redemption code uses info is likely to be something we need to always reflect the current value of to avoid big code drops leading to frustration as the cart fails to find tickets for some time after it ran out

#### Out of Scope

- Tech debt related to codes using 0 instead of just nullifying the field. That may require some frontend changes to support and worth adjusting in its own asana card to keep the scope constrained as I don't have as much availability to adjust that at the moment. 

#### Examples

Logic shows 1 remaining use of the code, a limit of 5 tickets, and a user_purchased_ticket_count of 4:

<img width="283" alt="Screen Shot 2020-03-30 at 3 32 57 PM" src="https://user-images.githubusercontent.com/1319304/77965550-3c049d00-72af-11ea-8f35-2871ff5f522f.png">

Adding two fails because there's only room for one additional:

<img width="536" alt="Screen Shot 2020-03-30 at 3 33 07 PM" src="https://user-images.githubusercontent.com/1319304/77965551-3c049d00-72af-11ea-980c-a5bf3987eafd.png">

Adding 1 still succeeds:
<img width="545" alt="Screen Shot 2020-03-30 at 3 33 13 PM" src="https://user-images.githubusercontent.com/1319304/77965552-3c9d3380-72af-11ea-84c7-6df322121164.png">

Trying to add code again shows it has 0 available remaining uses and 5 user_purchased_ticket_count so they can't add:
<img width="636" alt="Screen Shot 2020-03-30 at 3 33 43 PM" src="https://user-images.githubusercontent.com/1319304/77965553-3c9d3380-72af-11ea-97a0-91d1ae5b51f4.png">

Attempting to add leads to the DB returning an error:
<img width="515" alt="Screen Shot 2020-03-30 at 3 33 56 PM" src="https://user-images.githubusercontent.com/1319304/77965555-3c9d3380-72af-11ea-947a-659a6636e295.png">

After updating the code to max uses 0 (by clearing the field):
<img width="626" alt="Screen Shot 2020-03-30 at 6 11 00 PM" src="https://user-images.githubusercontent.com/1319304/77966832-dd8cee00-72b1-11ea-9c49-606f64370c9a.png">

## Release Details:
### Migrations
 * No Migrations

### Environment Variables
 * No change
